### PR TITLE
refactor: renames `StartPrompt` to `ChatPrompt`

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -16,7 +16,7 @@ import streamlit as st
 from emojificate.filter import emojificate
 
 from conversant.prompt_chatbot import PERSONA_MODEL_DIRECTORY, PromptChatbot
-from conversant.prompts.start_prompt import StartPrompt
+from conversant.prompts.chat_prompt import ChatPrompt
 
 
 class ParrotChatbot(PromptChatbot):
@@ -29,7 +29,7 @@ class ParrotChatbot(PromptChatbot):
     def __init__(self):
         super().__init__(
             client=None,
-            prompt=StartPrompt(
+            prompt=ChatPrompt(
                 preamble=(
                     "The Parrot Bot repeats back whatever is said to it "
                     "without using Cohere's large language models."

--- a/conversant/personas/client-support/config.json
+++ b/conversant/personas/client-support/config.json
@@ -8,7 +8,7 @@
         "temperature": 0.75,
         "stop_sequences": ["\n"]
     },
-    "start_prompt_config": {
+    "chat_prompt_config": {
         "preamble": "Below is a series of chats between Support Agent and User. Support Agent responds to User based on the <<DESCRIPTION>>.\n<<DESCRIPTION>>\nSupport Agent is a professional, high-end retail service professional who helps a User with their billing, shipping, bugfix, and other related issues.  Support Agent always speaks formally, using full sentences and proper punctuation. Support Agent tries to understand the User's issue in detail and suggests possible ways to fix the issue, always being polite.",
         "example_separator": "<<CONVERSATION>>\n",
         "headers": {

--- a/conversant/personas/fantasy-wizard/config.json
+++ b/conversant/personas/fantasy-wizard/config.json
@@ -8,7 +8,7 @@
         "temperature": 0.75,
         "stop_sequences": ["\n"]
     },
-    "start_prompt_config": {
+    "chat_prompt_config": {
         "preamble": "Below is a series of chats between Fantasy Wizard and User. Fantasy Wizard responds to User based on the <<DESCRIPTION>>.\n<<DESCRIPTION>>\nIn this chat, the Fantasy Wizard is from a distant, magical land. The Fantasy Wizard has lived eons, knows many esoteric spells, and loves to talk about past adventures. The fantasy wizard talks in old fashioned English, often referencing legendary places, creatures and artifacts.",
         "example_separator": "<<CONVERSATION>>\n",
         "headers": {

--- a/conversant/personas/fortune-teller/config.json
+++ b/conversant/personas/fortune-teller/config.json
@@ -8,7 +8,7 @@
         "temperature": 0.8,
         "stop_sequences": ["\n"]
     },
-    "start_prompt_config": {
+    "chat_prompt_config": {
         "preamble": "Below is a series of chats between Fortune Teller and User. Fortune Teller responds to User based on the <<DESCRIPTION>>.\n<<DESCRIPTION>>\nIn this chat, the magnificent Fortune Teller will answer all your questions. The Fortune Teller can read the future using her crystal ball, and with all her powers she can see everything. There are no secrets she can't tell, no lie she can't detect, and no future she can't see. She answers vaguely, using generic and mysterious sentences. When a user ends the conversation, the Fortune Teller also ends the conversation and says goodbye.",
         "example_separator": "<<CONVERSATION>>\n",
         "headers": {

--- a/conversant/personas/injured-person/config.json
+++ b/conversant/personas/injured-person/config.json
@@ -8,7 +8,7 @@
         "temperature": 0.75,
         "stop_sequences": ["\n"]
     },
-    "start_prompt_config": {
+    "chat_prompt_config": {
         "preamble": "Below is a series of chats between Injured Person and User. Injured Person responds to User based on the <<DESCRIPTION>>.\n<<DESCRIPTION>>\nIn this chat, an Injured Person is complaining about a broken arm. The Injured Person was climbing a tree, fell, and broke their arm about an hour ago. They are hoping that the User can help them out with some advice and ideas about what to do about their arm.",
         "example_separator": "<<CONVERSATION>>\n",
         "headers": {

--- a/conversant/personas/math-teacher/config.json
+++ b/conversant/personas/math-teacher/config.json
@@ -8,7 +8,7 @@
         "temperature": 0.75,
         "stop_sequences": ["\n"]
     },
-    "start_prompt_config": {
+    "chat_prompt_config": {
         "preamble": "Below is a series of chats between Math Teacher Bot and User. Math Teacher Bot responds to User based on the <<DESCRIPTION>>.\n<<DESCRIPTION>>\nIn this chat, a helpful math teacher, Math Teacher Bot, helps a user with math homework.",
         "example_separator": "<<CONVERSATION>>\n",
         "headers": {

--- a/conversant/personas/personal-trainer/config.json
+++ b/conversant/personas/personal-trainer/config.json
@@ -10,7 +10,7 @@
         "temperature": 0.75,
         "stop_sequences": ["\n"]
     },
-    "start_prompt_config": {
+    "chat_prompt_config": {
         "preamble": "Below is a series of chats between Personal Trainer Bot and User. Personal Trainer Bot responds to User based on the <<DESCRIPTION>>.\n<<DESCRIPTION>>\nIn this chat you will receive exercise recommendations from the famous Personal Trainer Bot, so that it is easier to train at home and adapt your workout. He will give you different exercises for your needs and encourage you to keep exercising.",
         "example_separator": "<<CONVERSATION>>\n",
         "headers": {

--- a/conversant/personas/watch-sales-agent/config.json
+++ b/conversant/personas/watch-sales-agent/config.json
@@ -8,7 +8,7 @@
         "temperature": 0.75,
         "stop_sequences": ["\n"]
     },
-    "start_prompt_config": {
+    "chat_prompt_config": {
         "preamble": "Below is a series of chats between Watch Sales Agent and User. Watch Sales Agent responds to User based on the <<DESCRIPTION>>.\n<<DESCRIPTION>>\nWatch Sales Agent is a professional, high-end retail service professional who sells wristwatches. Watch Sales Agent always speaks formally, using full sentences and proper punctuation. Watch Sales Agent is curious about the User and asks questions to understand what kinds of watches the User enjoys and what kinds of watches might be best for them. However, Watch Sales Agent never asks about sensitive topics like age or weight.",
         "example_separator": "<<CONVERSATION>>\n",
         "headers": {

--- a/conversant/prompt_chatbot.py
+++ b/conversant/prompt_chatbot.py
@@ -15,8 +15,8 @@ import cohere
 import jsonschema
 
 from conversant.chatbot import Chatbot
+from conversant.prompts.chat_prompt import ChatPrompt
 from conversant.prompts.prompt import Prompt
-from conversant.prompts.start_prompt import StartPrompt
 
 PERSONA_MODEL_DIRECTORY = "conversant/personas"
 PERSONA_JSON_SCHEMA = {
@@ -260,7 +260,7 @@ class PromptChatbot(Chatbot):
 
         return cls(
             client=client,
-            prompt=StartPrompt.from_dict(persona["start_prompt_config"]),
+            prompt=ChatPrompt.from_dict(persona["chat_prompt_config"]),
             persona_name=persona_name,
             chatbot_config=persona["chatbot_config"],
             client_config=persona["client_config"],

--- a/conversant/prompts/chat_prompt.py
+++ b/conversant/prompts/chat_prompt.py
@@ -16,8 +16,8 @@ from conversant.prompts.prompt import Prompt
 
 
 @dataclass
-class StartPrompt(Prompt):
-    """A start prompt given to a Chatbot.
+class ChatPrompt(Prompt):
+    """A chat prompt given to a Chatbot.
 
     Required fields:
         user: An entity speaking to the bot.
@@ -36,10 +36,10 @@ class StartPrompt(Prompt):
     MIN_NUM_EXAMPLES: int = 0
 
     def __post_init__(self) -> None:
-        """Validators for the start prompt.
+        """Validators for the chat prompt.
 
         Validates that the prompt follows the requirements of the validators listed below.
-        Minimally, the StartPrompt needs to follow the requirements of its parent class.
+        Minimally, the ChatPrompt needs to follow the requirements of its parent class.
         """
         super()._validate_preamble()
         super()._validate_example_separator()
@@ -52,7 +52,7 @@ class StartPrompt(Prompt):
         """
         Returns:
             str: The name of the user that interacts with the chatbot who uses this
-                StartPrompt. Typically this should be set to `'User'`.
+                ChatPrompt. Typically this should be set to `'User'`.
         """
         return self.headers["user"]
 
@@ -60,7 +60,7 @@ class StartPrompt(Prompt):
     def bot_name(self):
         """
         Returns:
-            str: The name of the chatbot who uses this StartPrompt.
+            str: The name of the chatbot who uses this ChatPrompt.
         """
         return self.headers["bot"]
 
@@ -197,7 +197,7 @@ class StartPrompt(Prompt):
                     turn.lstrip().startswith(self.bot_name) for turn in bot_turns
                 )
                 if user_prefixed and bot_prefixed:
-                    # It's hard to think of any genuine case where all utterances start with self-names.
+                    # It's hard to think of any genuine case where all utterances begin with self-names.
                     raise ValueError(
                         "Conversation interactions should not be prefixed with user/bot names!"
                     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,9 +16,9 @@ from cohere.embeddings import Embeddings
 from cohere.generation import Generation, Generations, TokenLikelihood
 
 from conversant.prompt_chatbot import PERSONA_MODEL_DIRECTORY, PromptChatbot
+from conversant.prompts.chat_prompt import ChatPrompt
 from conversant.prompts.prompt import Prompt
 from conversant.prompts.rewrite_prompt import RewritePrompt
-from conversant.prompts.start_prompt import StartPrompt
 from conversant.search.document import Document
 from conversant.search.local_searcher import LocalSearcher
 from conversant.search.searcher import Searcher
@@ -97,14 +97,14 @@ def mock_prompt(mock_prompt_config: Dict[str, Any]) -> Prompt:
 
 
 @pytest.fixture
-def mock_start_prompt_config() -> Dict[str, Any]:
-    """A StartPrompt config fixture for tests.
+def mock_chat_prompt_config() -> Dict[str, Any]:
+    """A ChatPrompt config fixture for tests.
 
     Returns:
-        Dict[str, Any]: Dictionary that can be used to construct to instantiate a StartPrompt.
+        Dict[str, Any]: Dictionary that can be used to construct to instantiate a ChatPrompt.
     """
     return {
-        "preamble": "This is a start prompt.",
+        "preamble": "This is a chat prompt.",
         "example_separator": "\n",
         "headers": {"user": "User", "bot": "Mock Chatbot"},
         "examples": [
@@ -130,13 +130,13 @@ def mock_start_prompt_config() -> Dict[str, Any]:
 
 
 @pytest.fixture
-def mock_start_prompt(mock_start_prompt_config: Dict[str, Any]) -> StartPrompt:
-    """A StartPrompt config fixture for tests.
+def mock_chat_prompt(mock_chat_prompt_config: Dict[str, Any]) -> ChatPrompt:
+    """A ChatPrompt config fixture for tests.
 
     Returns:
-        Dict[str, Any]: Dictionary that can be used to construct to instantiate a StartPrompt.
+        Dict[str, Any]: Dictionary that can be used to construct to instantiate a ChatPrompt.
     """
-    return StartPrompt(**mock_start_prompt_config)
+    return ChatPrompt(**mock_chat_prompt_config)
 
 
 @pytest.fixture
@@ -180,9 +180,7 @@ def mock_rewrite_prompt(mock_rewrite_prompt_config: Dict[str, Any]) -> RewritePr
 
 
 @pytest.fixture
-def mock_prompt_chatbot(
-    mock_co: object, mock_start_prompt: StartPrompt
-) -> PromptChatbot:
+def mock_prompt_chatbot(mock_co: object, mock_chat_prompt: ChatPrompt) -> PromptChatbot:
     """Instantiates a single bot fixture for tests.
 
     Returns:
@@ -190,7 +188,7 @@ def mock_prompt_chatbot(
     """
     return PromptChatbot(
         client=mock_co,
-        prompt=mock_start_prompt,
+        prompt=mock_chat_prompt,
     )
 
 

--- a/tests/prompts/test_start_prompt.py
+++ b/tests/prompts/test_start_prompt.py
@@ -10,39 +10,39 @@ from typing import Any, Dict
 
 import pytest
 
-from conversant.prompts.start_prompt import StartPrompt
+from conversant.prompts.chat_prompt import ChatPrompt
 
 
 @pytest.fixture
 def new_interaction() -> Dict[str, str]:
-    """Instantiates a fixture for a new StartPrompt example.
+    """Instantiates a fixture for a new ChatPrompt example.
 
     Returns:
-        Dict[str, str]: New StartPrompt interaction fixture.
+        Dict[str, str]: New ChatPrompt interaction fixture.
     """
     return {"user": "Nice to meet you!", "bot": "You too!"}
 
 
-def test_start_prompt_init(mock_start_prompt_config: Dict[str, Any]) -> None:
-    """Tests StartPrompt.__init__
+def test_chat_prompt_init(mock_chat_prompt_config: Dict[str, Any]) -> None:
+    """Tests ChatPrompt.__init__
 
     Args:
-        mock_start_prompt_config (Dict[str, Any]): A StartPrompt config fixture.
+        mock_chat_prompt_config (Dict[str, Any]): A ChatPrompt config fixture.
     """
-    start_prompt = StartPrompt(**mock_start_prompt_config)
-    assert start_prompt.user_name == "User"
-    assert start_prompt.bot_name == "Mock Chatbot"
+    chat_prompt = ChatPrompt(**mock_chat_prompt_config)
+    assert chat_prompt.user_name == "User"
+    assert chat_prompt.bot_name == "Mock Chatbot"
 
 
-def test_start_prompt_init_from_dict(mock_start_prompt_config: Dict[str, Any]) -> None:
-    """Tests StartPrompt.from_dict
+def test_chat_prompt_init_from_dict(mock_chat_prompt_config: Dict[str, Any]) -> None:
+    """Tests ChatPrompt.from_dict
 
     Args:
-        mock_start_prompt_config (Dict[str, Any]): A StartPrompt config fixture.
+        mock_chat_prompt_config (Dict[str, Any]): A ChatPrompt config fixture.
     """
-    start_prompt = StartPrompt.from_dict(mock_start_prompt_config)
-    assert start_prompt.user_name == "User"
-    assert start_prompt.bot_name == "Mock Chatbot"
+    chat_prompt = ChatPrompt.from_dict(mock_chat_prompt_config)
+    assert chat_prompt.user_name == "User"
+    assert chat_prompt.bot_name == "Mock Chatbot"
 
 
 @pytest.mark.parametrize(
@@ -89,41 +89,41 @@ def test_start_prompt_init_from_dict(mock_start_prompt_config: Dict[str, Any]) -
         "examples-prefixed-with-name",
     ],
 )
-def test_start_prompt_init_fails(
-    mock_start_prompt_config: Dict[str, Any], config
+def test_chat_prompt_init_fails(
+    mock_chat_prompt_config: Dict[str, Any], config
 ) -> None:
-    """Tests StartPrompt.__init__ on bad parameters.
+    """Tests ChatPrompt.__init__ on bad parameters.
 
     Args:
-        mock_start_prompt_config (Dict[str, Any]): A StartPrompt config fixture.
+        mock_chat_prompt_config (Dict[str, Any]): A ChatPrompt config fixture.
         config (Dict[str, Any]): Dictionary of bad parameters.
     """
-    mock_start_prompt_config.update(config)
+    mock_chat_prompt_config.update(config)
     with pytest.raises(ValueError):
-        _ = StartPrompt(**mock_start_prompt_config)
+        _ = ChatPrompt(**mock_chat_prompt_config)
 
 
-def test_start_prompt_create_interaction_string(
-    mock_start_prompt: StartPrompt, new_interaction: Dict[str, str]
+def test_chat_prompt_create_interaction_string(
+    mock_chat_prompt: ChatPrompt, new_interaction: Dict[str, str]
 ) -> None:
-    """Tests StartPrompt.create_interaction_string
+    """Tests ChatPrompt.create_interaction_string
 
     Args:
-        mock_start_prompt (StartPrompt): A StartPrompt fixture.
-        new_interaction (Dict[ str, str]): A new StartPrompt interaction fixture.
+        mock_chat_prompt (ChatPrompt): A ChatPrompt fixture.
+        new_interaction (Dict[ str, str]): A new ChatPrompt interaction fixture.
     """
     expected = (
-        f"{mock_start_prompt.headers['user']}: {new_interaction['user']}\n"
-        f"{mock_start_prompt.headers['bot']}: {new_interaction['bot']}\n"
+        f"{mock_chat_prompt.headers['user']}: {new_interaction['user']}\n"
+        f"{mock_chat_prompt.headers['bot']}: {new_interaction['bot']}\n"
     )
     # create from positional arguments
-    generated_interaction_str = mock_start_prompt.create_interaction_string(
+    generated_interaction_str = mock_chat_prompt.create_interaction_string(
         new_interaction["user"], new_interaction["bot"]
     )
     assert generated_interaction_str == expected
 
     # create from keyword arguments
-    generated_interaction_str = mock_start_prompt.create_interaction_string(
+    generated_interaction_str = mock_chat_prompt.create_interaction_string(
         **new_interaction
     )
     assert generated_interaction_str == expected
@@ -134,32 +134,32 @@ def test_start_prompt_create_interaction_string(
     reordered_interaction["bot"] = new_interaction["bot"]
     reordered_interaction["user"] = new_interaction["user"]
     reordered_expected = (
-        f"{mock_start_prompt.headers['bot']}: {new_interaction['bot']}\n"
-        f"{mock_start_prompt.headers['user']}: {new_interaction['user']}\n"
+        f"{mock_chat_prompt.headers['bot']}: {new_interaction['bot']}\n"
+        f"{mock_chat_prompt.headers['user']}: {new_interaction['user']}\n"
     )
-    generated_reordered_interaction_str = mock_start_prompt.create_interaction_string(
+    generated_reordered_interaction_str = mock_chat_prompt.create_interaction_string(
         **reordered_interaction
     )
     assert generated_reordered_interaction_str == reordered_expected
 
 
-def test_start_prompt_to_string(mock_start_prompt: StartPrompt) -> None:
-    """Tests StartPrompt.to_string
+def test_chat_prompt_to_string(mock_chat_prompt: ChatPrompt) -> None:
+    """Tests ChatPrompt.to_string
 
     Args:
-        mock_start_prompt (StartPrompt): A StartPrompt fixture.
+        mock_chat_prompt (ChatPrompt): A ChatPrompt fixture.
     """
     expected = (
-        f"{mock_start_prompt.preamble}\n"
-        f"{mock_start_prompt.example_separator}"
-        f"{mock_start_prompt.headers['user']}: {mock_start_prompt.examples[0][0]['user']}\n"
-        f"{mock_start_prompt.headers['bot']}: {mock_start_prompt.examples[0][0]['bot']}\n"
-        f"{mock_start_prompt.headers['user']}: {mock_start_prompt.examples[0][1]['user']}\n"
-        f"{mock_start_prompt.headers['bot']}: {mock_start_prompt.examples[0][1]['bot']}\n"
-        f"{mock_start_prompt.example_separator}"
-        f"{mock_start_prompt.headers['user']}: {mock_start_prompt.examples[1][0]['user']}\n"
-        f"{mock_start_prompt.headers['bot']}: {mock_start_prompt.examples[1][0]['bot']}\n"
-        f"{mock_start_prompt.headers['user']}: {mock_start_prompt.examples[1][1]['user']}\n"
-        f"{mock_start_prompt.headers['bot']}: {mock_start_prompt.examples[1][1]['bot']}"
+        f"{mock_chat_prompt.preamble}\n"
+        f"{mock_chat_prompt.example_separator}"
+        f"{mock_chat_prompt.headers['user']}: {mock_chat_prompt.examples[0][0]['user']}\n"
+        f"{mock_chat_prompt.headers['bot']}: {mock_chat_prompt.examples[0][0]['bot']}\n"
+        f"{mock_chat_prompt.headers['user']}: {mock_chat_prompt.examples[0][1]['user']}\n"
+        f"{mock_chat_prompt.headers['bot']}: {mock_chat_prompt.examples[0][1]['bot']}\n"
+        f"{mock_chat_prompt.example_separator}"
+        f"{mock_chat_prompt.headers['user']}: {mock_chat_prompt.examples[1][0]['user']}\n"
+        f"{mock_chat_prompt.headers['bot']}: {mock_chat_prompt.examples[1][0]['bot']}\n"
+        f"{mock_chat_prompt.headers['user']}: {mock_chat_prompt.examples[1][1]['user']}\n"
+        f"{mock_chat_prompt.headers['bot']}: {mock_chat_prompt.examples[1][1]['bot']}"
     )
-    assert mock_start_prompt.to_string() == expected
+    assert mock_chat_prompt.to_string() == expected

--- a/tests/test_prompt_chatbot.py
+++ b/tests/test_prompt_chatbot.py
@@ -11,7 +11,7 @@ import itertools
 import pytest
 
 from conversant.prompt_chatbot import PromptChatbot
-from conversant.prompts.start_prompt import StartPrompt
+from conversant.prompts.chat_prompt import ChatPrompt
 
 
 def check_prompt_chatbot_config(prompt_chatbot: PromptChatbot):
@@ -95,7 +95,7 @@ def test_prompt_chatbot_get_current_prompt(
 
     current_prompt = mock_prompt_chatbot.get_current_prompt(query="Hello!")
     expected = (
-        # start prompt
+        # chat prompt
         f"{mock_prompt_chatbot.prompt.preamble}\n"
         + f"{mock_prompt_chatbot.prompt.example_separator}"
         + f"{mock_prompt_chatbot.prompt.headers['user']}: {mock_prompt_chatbot.prompt.examples[0][0]['user']}\n"


### PR DESCRIPTION
### What this PR does
- Renames instances of `StartPrompt` and `start_prompt` to `ChatPrompt` and `chat_prompt` respectively.

The previous name `StartPrompt` doesn't have enough detail of its purpose, which is to begin a chat dialogue. `ChatPrompt` is preferred as it makes explicit that a `PromptChatbot` class is a chatbot because it has a `ChatPrompt`.
Closes #1 


### How it was tested
- All tests pass
- Streamlit demo runs


### PR checklist

- [x] No API keys or other secrets committed to source?
- [x] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
