### PR TITLE
fix: doc workflow for Github Actions

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -1,10 +1,10 @@
 name: build docs
 
 # build the documentation whenever there are new commits on main
-on: [push]
-  # push:
-  #   branches:
-  #     - main
+on:
+  push:
+    branches:
+      - main
     # Alternative: only build for tags.
     # tags:
     #   - '*'


### PR DESCRIPTION
### What this PR does
- Fixes Github Actions workflow for building docs


### How it was tested
- Doc building now works on separate branch
- Deploy fails as expected on non-main branches due to environment protection rules; should work on `main` once merged though (famous last words)


### PR checklist

- [x] No API keys or other secrets committed to source?
- [x] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
