### PR TITLE
fix: add imports in __init__

### DIFF
--- a/conversant/__init__.py
+++ b/conversant/__init__.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2022 Cohere Inc. and its affiliates.
+#
+# Licensed under the MIT License (the "License");
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License in the LICENSE file at the top
+# level of this repository.
+
 from conversant.chatbot import Chatbot
 from conversant.prompt_chatbot import PromptChatbot
 

--- a/conversant/__init__.py
+++ b/conversant/__init__.py
@@ -1,0 +1,4 @@
+from conversant.chatbot import Chatbot
+from conversant.prompt_chatbot import PromptChatbot
+
+__all__ = ["Chatbot", "PromptChatbot"]

--- a/conversant/prompts/__init__.py
+++ b/conversant/prompts/__init__.py
@@ -1,0 +1,5 @@
+from conversant.prompts.chat_prompt import ChatPrompt
+from conversant.prompts.prompt import Prompt
+from conversant.prompts.rewrite_prompt import RewritePrompt
+
+__all__ = ["Prompt", "ChatPrompt", "RewritePrompt"]

--- a/conversant/prompts/__init__.py
+++ b/conversant/prompts/__init__.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2022 Cohere Inc. and its affiliates.
+#
+# Licensed under the MIT License (the "License");
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License in the LICENSE file at the top
+# level of this repository.
+
 from conversant.prompts.chat_prompt import ChatPrompt
 from conversant.prompts.prompt import Prompt
 from conversant.prompts.rewrite_prompt import RewritePrompt

--- a/conversant/search/__init__.py
+++ b/conversant/search/__init__.py
@@ -1,0 +1,5 @@
+from conversant.search.document import Document
+from conversant.search.local_searcher import LocalSearcher
+from conversant.search.searcher import Searcher
+
+__all__ = ["Document", "Searcher", "LocalSearcher"]

--- a/conversant/search/__init__.py
+++ b/conversant/search/__init__.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2022 Cohere Inc. and its affiliates.
+#
+# Licensed under the MIT License (the "License");
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License in the LICENSE file at the top
+# level of this repository.
+
 from conversant.search.document import Document
 from conversant.search.local_searcher import LocalSearcher
 from conversant.search.searcher import Searcher

--- a/conversant/utils/__init__.py
+++ b/conversant/utils/__init__.py
@@ -1,1 +1,9 @@
+# Copyright (c) 2022 Cohere Inc. and its affiliates.
+#
+# Licensed under the MIT License (the "License");
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License in the LICENSE file at the top
+# level of this repository.
+
 __all__ = ["demo_utils"]

--- a/conversant/utils/__init__.py
+++ b/conversant/utils/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["demo_utils"]


### PR DESCRIPTION
### What this PR does
- Adds imports in respective submodules so that the following commands work
```
import conversant
from conversant import PromptChatbot
from conversant.prompts import ChatPrompt
from conversant.search import Searcher
from conversant.utils import demo_utils

bot = conversant.PromptChatbot.from_persona("fantasy-wizard", client=co)
```
This enables the code examples in the README to work.

Open to push back on whether we are okay with users using conversant / importing submodules this way. We can discuss below 😄 

### How it was tested
- Ran above commands locally


### PR checklist

- [x] No API keys or other secrets committed to source?
- [x] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

~<ins>**Do we need to include the license header in `__init__.py` files?**</ins>~ Yes

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
