### PR TITLE
fix: encode chatbot without cohere client, decode with client

### DIFF
--- a/app/streamlit_example.py
+++ b/app/streamlit_example.py
@@ -31,8 +31,8 @@ def get_reply() -> None:
 def initialize_chatbot() -> None:
     """Initializes the chatbot from a selected persona and saves the session state."""
     if st.session_state.persona.startswith("from launch_demo") and len(sys.argv) > 1:
-        st.session_state.bot = demo_utils.decode_object(
-            sys.argv[1]
+        st.session_state.bot = demo_utils.decode_chatbot(
+            sys.argv[1], client=cohere.Client(st.secrets.COHERE_API_KEY)
         )  # Launched via demo_utils.launch_streamlit() utility function
     elif st.session_state.persona == "":
         st.session_state.bot = None
@@ -109,8 +109,10 @@ if __name__ == "__main__":
 
         # The PromptChatbot passed in should be a base64 encoding of a pickled
         # PromptChatbot object.
-        bot = demo_utils.decode_object(sys.argv[1])
-        if bot.__class__ != PromptChatbot:
+        bot = demo_utils.decode_chatbot(
+            sys.argv[1], cohere.Client(st.secrets.COHERE_API_KEY)
+        )
+        if not isinstance(bot, PromptChatbot):
             raise TypeError("base64 string passed in is not of class PromptChatbot")
         else:
             st.session_state.bot = bot

--- a/app/utils.py
+++ b/app/utils.py
@@ -80,7 +80,7 @@ def get_twemoji_url_from_shortcode(shortcode: str) -> str:
     return url
 
 
-@st.cache
+@st.cache(allow_output_mutation=True)
 def get_persona_options() -> List[str]:
     """Initializes a list of personas.
 

--- a/conversant/utils/demo_utils.py
+++ b/conversant/utils/demo_utils.py
@@ -11,36 +11,40 @@ import pickle
 import sys
 from typing import Type
 
+import cohere
 from streamlit.web import cli as stcli
 
 from conversant.chatbot import Chatbot
 
 
-def encode_object(obj: object) -> str:
-    """Serialize and encode an object to a base-64 string encoding.
+def encode_chatbot(chatbot: Type[Chatbot]) -> str:
+    """Serialize and encode a Chatbot object to a base-64 string encoding.
 
     Args:
-        obj (object): a Python object
+        chatbot (object): a chatbot of class inherited from Chatbot
 
     Returns:
-        str: object as a base-64 string
+        str: Chatbot object as a base-64 string
     """
-    return codecs.encode(pickle.dumps(obj), "base64").decode()
+    chatbot.co = None
+    return codecs.encode(pickle.dumps(chatbot), "base64").decode()
 
 
-def decode_object(obj_string: str) -> object:
-    """Decode and deserialize an object,
+def decode_chatbot(chatbot_string: str, client: cohere.Client) -> Type[Chatbot]:
+    """Decode and deserialize a Chatbot object.
 
     Args:
         obj_string (str): a base-64 string encoding
 
     Returns:
-        object: a Python object
+        Type[Chatbot]: a chatbot of class inherited rom Chatbot
     """
-    return pickle.loads(codecs.decode(obj_string.encode(), "base64"))
+    chatbot = pickle.loads(codecs.decode(chatbot_string.encode(), "base64"))
+    chatbot.co = client
+    return chatbot
 
 
-def launch_streamlit(bot: Type[Chatbot]) -> None:
+def launch_streamlit(chatbot: Type[Chatbot]) -> None:
     """Launches a demo of a chatbot using Streamlit.
 
     The bot will be a persona available for chatting using the interface
@@ -50,5 +54,5 @@ def launch_streamlit(bot: Type[Chatbot]) -> None:
         bot (Type[Chatbot]): a chatbot of class inherited from Chatbot
     """
     sys.argv = "streamlit run app/streamlit_example.py --".split(" ")
-    sys.argv.append(encode_object(bot))
+    sys.argv.append(encode_chatbot(chatbot))
     sys.exit(stcli.main())

--- a/tests/utils/test_demo_utils.py
+++ b/tests/utils/test_demo_utils.py
@@ -5,13 +5,18 @@
 #
 # You may obtain a copy of the License in the LICENSE file at the top
 # level of this repository.
+import cohere
 
 from conversant.prompt_chatbot import PromptChatbot
 from conversant.utils import demo_utils
 
 
-def test_encode_decode_object(mock_prompt_chatbot: PromptChatbot) -> None:
+def test_encode_decode_mock(
+    mock_prompt_chatbot: PromptChatbot, mock_co: cohere.Client
+) -> None:
     assert isinstance(
-        demo_utils.decode_object(demo_utils.encode_object(mock_prompt_chatbot)),
+        demo_utils.decode_chatbot(
+            demo_utils.encode_chatbot(mock_prompt_chatbot), client=mock_co
+        ),
         PromptChatbot,
     )

--- a/tests/utils/test_demo_utils.py
+++ b/tests/utils/test_demo_utils.py
@@ -11,7 +11,7 @@ from conversant.prompt_chatbot import PromptChatbot
 from conversant.utils import demo_utils
 
 
-def test_encode_decode_mock(
+def test_encode_decode_chatbot(
     mock_prompt_chatbot: PromptChatbot, mock_co: cohere.Client
 ) -> None:
     assert isinstance(


### PR DESCRIPTION
### What this PR does
- The cohere client cannot be pickled as it contains a `ThreadPoolExecutor` object.
- Before calling `pickle.dumps`, set the client to None, then encode object without a Cohere client
- When decoding, a cohere client needs to be passed in (this is also more secure).

Closes #45 

### How it was tested
- Tested locally with these commands
```python
co = cohere.Client("API KEY")
shakespeare_config = {
    "preamble": "Below is a conversation between Shakespeare and a Literature Student.",
    "example_separator": "<CONVERSATION>\n",
    "headers": {
        "user": "Literature Student",
        "bot": "William Shakespeare",
    },
    "examples": [
        [
            {
                "user": "Who are you?",
                "bot": "Mine own nameth is Shakespeare, and I speaketh in riddles.",
            },
        ]
    ],
}
shakespeare_bot = PromptChatbot(
    client=co,
    prompt=ChatPrompt.from_dict(shakespeare_config),
    persona_name="william-shakespeare",
)
demo_utils.launch_streamlit(shakespeare_bot)
```

Demo launches successfully and able to speak to shakespeare bot


### PR checklist

- [x] No API keys or other secrets committed to source?
- [x] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
