### PR TITLE
fix: update prefix in persona selection

### DIFF
--- a/conversant/demo/streamlit_example.py
+++ b/conversant/demo/streamlit_example.py
@@ -31,7 +31,7 @@ def get_reply() -> None:
 
 def initialize_chatbot() -> None:
     """Initializes the chatbot from a selected persona and saves the session state."""
-    if st.session_state.persona.startswith("from launch_demo") and len(sys.argv) > 1:
+    if st.session_state.persona.startswith("(launched)") and len(sys.argv) > 1:
         st.session_state.bot = demo_utils.decode_chatbot(
             sys.argv[1], client=cohere.Client(os.environ.get("COHERE_API_KEY"))
         )  # Launched via demo_utils.launch_streamlit() utility function
@@ -125,7 +125,7 @@ if __name__ == "__main__":
         else:
             st.session_state.bot = bot
             st.session_state.persona_options.insert(
-                0, f"from launch_demo: {st.session_state.bot.persona_name}"
+                0, f"(launched) {st.session_state.bot.persona_name}"
             )
 
     # Page control flow logic is determined from the sidebar.


### PR DESCRIPTION
### What this PR does
- Previously when launching a chatbot using `demo_utils.launch_streamlit()`, the streamlit example would have "from launch_demo: {persona_name}". This was written when the function was called `launch_demo` previously.
- Now it will be "(launched) {persona_name}".

Closes #48 

### How it was tested
Local streamlit:
![Screen Shot 2022-11-07 at 7 16 22 PM](https://user-images.githubusercontent.com/32623504/200297462-3a3c1c62-0896-497c-b58e-ccabb55a61d2.png)



### PR checklist

- [x] No API keys or other secrets committed to source?
- [x] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
