### PR TITLE
add css styling to resolve top/bottom chat issue

### DIFF
--- a/conversant/demo/streamlit_example.py
+++ b/conversant/demo/streamlit_example.py
@@ -15,6 +15,7 @@ import sys
 import cohere
 import emoji
 import streamlit as st
+
 from conversant.demo import ui, utils
 from conversant.prompt_chatbot import PromptChatbot
 from conversant.utils import demo_utils
@@ -130,7 +131,7 @@ if __name__ == "__main__":
     # Adding a header to direct users to sign up for Cohere, explore the playground,
     # and check out our git repo.
     st.header("🎭 Conversational personas using Cohere")
-    with st.expander("About", expanded=True):
+    with st.expander("About", expanded="bot" not in st.session_state):
         st.markdown(
             """
         This demo app is using 
@@ -244,17 +245,6 @@ if __name__ == "__main__":
                 with prompt_string_placeholder.container():
                     ui.draw_prompt_view(json=False)
 
-            # When in editor view, elements should anchored from the top.
-            utils.style_using_css(
-                """
-                div.css-18e3th9.egzxvld2 {
-                    display: flex;
-                    align-items: flex-start;
-                    overflow: visible;
-                }
-            """
-            )
-
         # Chat view with the persona
         else:
 
@@ -298,11 +288,8 @@ if __name__ == "__main__":
             # When in chat view, anchor elements from the bottom so that
             # the message input field is at the bottom (more natural).
             utils.style_using_css(
-                """
-                div.css-18e3th9.egzxvld2 {
-                    display: flex;
-                    align-items: flex-end;
-                    overflow: visible;
+                """div.css-18e3th9.egzxvld2 > div:nth-child(1) > div:nth-child(1) > div:nth-child(6) { /* # noqa */
+                    margin-top: auto;
                 }
             """
             )

--- a/conversant/demo/styles.css
+++ b/conversant/demo/styles.css
@@ -1,10 +1,15 @@
 /* Style the overall app container */
 div.css-18e3th9.egzxvld2 {
     padding: 1rem 1rem 1rem;
+    display: flex;
+    overflow: visible;
+}
+.css-ocqkz7 {
+    flex-grow: 0;
 }
 
 /* Style chat_history_placeholder so overflow messages are scrollable */
-div.css-18e3th9.egzxvld2 > div:nth-child(1) > div:nth-child(1) > div:nth-child(4) > div:nth-child(2) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) {
+div.css-18e3th9.egzxvld2 > div:nth-child(1) > div:nth-child(1) > div:nth-child(6) > div:nth-child(2) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) {
     display: flex;
     flex-direction: column-reverse;
     overflow-x: hidden;
@@ -13,12 +18,12 @@ div.css-18e3th9.egzxvld2 > div:nth-child(1) > div:nth-child(1) > div:nth-child(4
 }
 
 /* Style prompt_json_view_placeholder header so it is aligned. */
-div.css-18e3th9.egzxvld2 > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) p {
+div.css-18e3th9.egzxvld2 > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) p {
     margin-left: 8px;
 }
 
 /* Style prompt_json_view_placeholder so overflow is scrollable */
-div.css-18e3th9.egzxvld2 > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(1) > div:nth-child(2) {
+div.css-18e3th9.egzxvld2 > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(1) > div:nth-child(2) {
     overflow-x: hidden;
     overflow-y: scroll;
     max-height: 955px;
@@ -27,7 +32,7 @@ div.css-18e3th9.egzxvld2 > div:nth-child(1) > div:nth-child(1) > div:nth-child(5
 }
 
 /* Style prompt_string_placeholder so overflow is scrollable */
-div.css-18e3th9.egzxvld2 > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(2) .stCodeBlock {
+div.css-18e3th9.egzxvld2 > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(2) .stCodeBlock {
     overflow-x: hidden;
     overflow-y: scroll;
     max-height: 955px;


### PR DESCRIPTION
### What this PR does
- Changed the CSS selector for chat history placeholder and prompt json / string placeholder
- About expander expands only if there is no bot in session state. (i.e. collapses after choosing a persona)
- Changed CSS styling so that the header is at the top, and chat history is anchored at the bottom


### How it was tested
- Local streamlit:
![Screen Shot 2022-11-08 at 6 54 41 PM](https://user-images.githubusercontent.com/32623504/200557470-fb6baa7e-abfc-4eee-891f-7c5dac098fea.png)



### PR checklist

- [x] No API keys or other secrets committed to source?
- [x] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
