### PR TITLE
fix: update poetry version in CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -49,7 +49,7 @@ conda activate conversant
 
 Install `poetry`:
 ```
-pip install poetry==1.3.2
+pip install poetry==1.2.2
 ```
 
 Set `poetry` to use the Python installed in the `conversant` environment:

--- a/poetry.lock
+++ b/poetry.lock
@@ -411,8 +411,8 @@ python-versions = ">=3.8"
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
     {version = ">=1.20.3", markers = "python_version < \"3.10\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
 ]
 python-dateutil = ">=2.8.1"
 pytz = ">=2020.1"
@@ -933,7 +933,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "a2729d42252a5a40fff5e4916b795dd8fc0d40872d9a5c9f7f05abe114ad8bea"
+content-hash = "312995634ab8991faa9caf321185d3a5b77acb8a868490e756ccaf5f9330d740"
 
 [metadata.files]
 altair = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ pydantic = "^1.10.2"
 emoji = "^2.1.0"
 emojificate = "^0.6.0"
 streamlit-ace = "^0.1.1"
-streamlit-talk = "^v0.0.3"
+streamlit-talk = "^0.0.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.2"


### PR DESCRIPTION
### What this PR does
- The poetry version was incorrectly listed as 1.3.2 in `CONTRIBUTORS.md`. This fixes it to 1.2.2
- Also fix a typo in streamlit-talk version in pyproject.toml


### How it was tested
- Doc change
- Installed streamlit-talk successfully


### PR checklist

- [x] No API keys or other secrets committed to source?
- [x] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
