### PR TITLE
test: remove lambda filter from parametrized get_current_prompt test

### DIFF
--- a/tests/test_prompt_chatbot.py
+++ b/tests/test_prompt_chatbot.py
@@ -77,10 +77,7 @@ def test_prompt_chatbot_init_from_persona(mock_co: object) -> None:
 @pytest.mark.parametrize(
     "max_context_examples, history_length",
     list(
-        filter(
-            lambda items: items[0] <= items[1],
-            itertools.product(list(range(0, 20, 4)), list(range(0, 50, 10))),
-        )
+        itertools.product(list(range(0, 20, 4)), list(range(0, 50, 10))),
     ),
 )
 def test_prompt_chatbot_get_current_prompt(
@@ -98,7 +95,7 @@ def test_prompt_chatbot_get_current_prompt(
     """
     chat_history = [
         {"user": f"Hello! {i}", "bot": f"Hello back! {i}"}
-        for i in range(history_length + 1)
+        for i in range(1, history_length + 1)
     ]
     mock_prompt_chatbot.chat_history = chat_history
     mock_prompt_chatbot.configure_chatbot(
@@ -129,8 +126,10 @@ def test_prompt_chatbot_get_current_prompt(
                     f"{mock_prompt_chatbot.prompt.headers['user']}: Hello! {i}\n"
                     f"{mock_prompt_chatbot.prompt.headers['bot']}: Hello back! {i}\n"
                 )
-                for i in range(
-                    history_length - max_context_examples + 1, history_length + 1
+                for i in (
+                    list(range(1, history_length + 1))[-max_context_examples:]
+                    if max_context_examples > 0
+                    else []
                 )
             ]
         )


### PR DESCRIPTION
### What this PR does
- We should test for instances where `max_context_examples` is higher than `history_length`, which is a common occurrence in the beginning of chats.
- No change to `get_current_prompt` function

### How it was tested
- Test passes


### PR checklist

- [x] No API keys or other secrets committed to source?
- [x] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
