### PR TITLE
docs: Update PyPI metadata and changelog for release of conversant v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.1.2 (2022-11-14)
 
 ### Added
-- Added Streamlit demo app to to `conversant`
+- Added Streamlit demo app to `conversant`
 
 ### Changed
 - Updated README content

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.1.2 (2022-11-14)
+
+### Added
+- Added Streamlit demo app to to `conversant`
+
+### Changed
+- Updated README content
+- Updated default persona directory 
+
+### Removed
+- N/A
+
 ## 0.1.1 (2022-11-02)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ pip install conversant
 Want to see it in action first? You can use `conversant` on a [Streamlit](https://docs.streamlit.io/) app without installing anything [here](https://conversant.streamlit.app/)! 🎉
 
 <p float="none">
-  <img src="static/fortune-teller-setup.png" alt="Screenshot showing the available personas on the Streamlit demo, with the Fortune Teller persona selected by default.." height="550"/>
-  <img src="static/fortune-teller-chat.png" alt="Screenshot showing an exchange between a Fortune Teller chatbot and a user." height="550"/>
+  <img src="https://github.com/cohere-ai/sandbox-conversant-lib/raw/main/static/fortune-teller-setup.png" alt="Screenshot showing the available personas on the Streamlit demo, with the Fortune Teller persona selected by default.." height="550"/>
+  <img src="https://github.com/cohere-ai/sandbox-conversant-lib/raw/main/static/fortune-teller-chat.png" alt="Screenshot showing an exchange between a Fortune Teller chatbot and a user." height="550"/>
 </p>
 
 ### Running Your Own Demo Locally
@@ -123,7 +123,7 @@ The config file should contain the following:
 
 ### Editing a Persona on the Demo
 You can also edit a persona on the Streamlit app!
-<img src="static/fortune-teller-edit.png" alt="Screenshot showing the interface for editing a persona on the Streamlit app."/>
+<img src="https://github.com/cohere-ai/sandbox-conversant-lib/raw/main/static/fortune-teller-edit.png" alt="Screenshot showing the interface for editing a persona on the Streamlit app."/>
 
 ### Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "conversant"
-version = "0.1.1"
+version = "0.1.2"
 repository = "https://github.com/cohere-ai/sandbox-conversant-lib"
 description = "Conversational AI tooling"
 readme = "README.md"


### PR DESCRIPTION
### What this PR does

Closes #69 

This updates `CHANGELOG.md` in order to prepare for a new PyPI release (version 0.1.2). The `CHANGELOG` reflects the changes shown here: https://github.com/cohere-ai/sandbox-conversant-lib/compare/e5155e2..6cd00e3 

This also changes the images in the README to use external links, as the internal links do not display correctly in the PyPI docs. 

Once this is merged, I will release the new version on PyPI via `poetry publish --build`.

### How it was tested

Documentation changes only. Confirmed that images display correctly in GitHub README.

### PR checklist

- [x] No API keys or other secrets committed to source?
- [x] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
