### PR TITLE
fix isort and black conflict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     rev: 5.10.1
     hooks:
     -   id: isort
-        args: [--line-width=88, --force-grid-wrap=0, --use-parentheses, --multi-line=0, --float-to-top]
+        args: [--profile=black, --line-width=88, --force-grid-wrap=0, --use-parentheses, --float-to-top]
 -   repo: https://github.com/psf/black
     rev: 22.10.0
     hooks:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -114,7 +114,7 @@ To avoid `pre-commit` hooks formatting files only right before a commit, we reco
             },
             {
                 "match": ".py$",
-                "cmd": "isort --line-width 88 --force-grid-wrap 0 --use-parentheses --multi-line 0 --float-to-top ${file}"
+                "cmd": "isort --profile black --line-width 88 --force-grid-wrap 0 --use-parentheses --float-to-top ${file}"
             },
             {
                 "match": ".py$",


### PR DESCRIPTION
### What this PR does
- Fixes an isort and black conflict in pre-commit hook

This issue arises in this example:
```python
from datetime import date

from cost_categories import (
    applsj,
    asjdfsi,
    bananana,
    sdjffsd,
    sjdifjsl,
    sjdil,
    yoyoyoyoy,
)
from library_user import User
```
taken from https://github.com/PyCQA/isort/issues/1518

### How it was tested
- isort follows black style for the above example 

### PR checklist

- [x] No API keys or other secrets committed to source?
- [x] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
