### PR TITLE
feat: streamline custom persona injection in streamlit (fixes CNV-25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ The config file should contain the following:
 
 `conversant` will take care of the rest! As an example, check out [`fortune-teller/config.json`](/conversant/personas/fortune-teller/config.json). When you launch the Streamlit app, the new persona will appear in the drop down menu.
 
+#### Troubleshooting missing personas
+
+If you do not see the new persona in the drop down menu, you may need to specify a 
+custom persona directory. In the demo Streamlit app (`streamlit_example.py`), one of the 
+first lines reads `CUSTOM_PERSONA_DIRECTORY = None`. Change this to specify the desired 
+persona directory, e.g. `CUSTOM_PERSONA_DIRECTORY = "/Users/yourname/custom-personas"`.
+
+If this is unchanged, the app will default to using the directory that contains the 
+`conversant` demo personas.
+
 ### Editing a Persona on the Demo
 You can also edit a persona on the Streamlit app!
 <img src="https://github.com/cohere-ai/sandbox-conversant-lib/raw/main/static/fortune-teller-edit.png" alt="Screenshot showing the interface for editing a persona on the Streamlit app."/>

--- a/conversant/demo/streamlit_example.py
+++ b/conversant/demo/streamlit_example.py
@@ -20,6 +20,11 @@ from conversant.demo import ui, utils
 from conversant.prompt_chatbot import PromptChatbot
 from conversant.utils import demo_utils
 
+# Set a custom persona directory by changing the following line
+# e.g. "/Users/yourname/custom-personas"
+# If the line is left as `CUSTOM_PERSONA_DIRECTORY = None`
+# the Streamlit app will use the demo presets
+CUSTOM_PERSONA_DIRECTORY = None
 USER_AVATAR_SHORTCODE = ":bust_in_silhouette:"
 
 
@@ -100,7 +105,12 @@ if __name__ == "__main__":
 
     # Each persona is a directory in PERSONA_MODEL_DIRECTORY, each with its
     # config.json file.
-    st.session_state.persona_options = utils.get_persona_options()
+    if CUSTOM_PERSONA_DIRECTORY:
+        st.session_state.persona_options = utils.get_persona_options(
+            CUSTOM_PERSONA_DIRECTORY
+        )
+    else:
+        st.session_state.persona_options = utils.get_persona_options()
 
     # Check if COHERE_API_KEY is not set from secrets.toml or os.environ
     if "COHERE_API_KEY" not in os.environ:

--- a/conversant/demo/utils.py
+++ b/conversant/demo/utils.py
@@ -81,23 +81,25 @@ def get_twemoji_url_from_shortcode(shortcode: str) -> str:
 
 
 @st.cache(allow_output_mutation=True)
-def get_persona_options() -> List[str]:
+def get_persona_options(persona_directory: str = PERSONA_MODEL_DIRECTORY) -> List[str]:
     """Initializes a list of personas.
 
-    Each persona is a directory in PERSONA_MODEL_DIRECTORY, each with its
+    Each persona is a directory in persona_directory, each with its
     config.json file. The mock parrot persona is also included for testing
     purposes.
+
+    Args:
+        persona_directory (str): Directory where persona folders containing config
+        files are stored. Defaults to PERSONA_MODEL_DIRECTORY.
 
     Returns:
         List[str]: A list of persona names.
     """
     # Initialize the list of personas for Streamlit
-    persona_names = os.listdir(PERSONA_MODEL_DIRECTORY)
+    persona_names = os.listdir(persona_directory)
     persona_names_maybe_with_emojis = []
     for persona_name in persona_names:
-        persona_path = os.path.join(
-            PERSONA_MODEL_DIRECTORY, persona_name, "config.json"
-        )
+        persona_path = os.path.join(persona_directory, persona_name, "config.json")
         with open(persona_path) as f:
             persona = json.load(f)
             avatar = (


### PR DESCRIPTION
### What this PR does

- modifies `get_persona_options` to accept a custom persona directory
- adds control flow logic to use a custom persona directory (`CUSTOM_PERSONA_DIRECTORY`) if it is specified in `streamlit_example.py`
- updates the README to reflect this change 

### How it was tested

- created a new environment with conversant installed from pip and replicated the problematic behaviour reported by users
- replicating the behaviour was non-trivial: in the same environment, I found that the default behaviour varied based on where the streamlit app was saved relative to the demo personas
- created a custom persona directory and tested using it in the streamlit app, confirmed that this resolves the problematic behavior
- tried using incorrect directories and confirmed that the error messages are sensible

### PR checklist

- [x] No API keys or other secrets committed to source?
- [ ] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
