### PR TITLE
docs: Update README, CHANGELOG, and PyPI metadata for release of conversant v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.1.3 (2022-12-02)
+
+### Added
+- N/A
+
+### Changed
+- Updated README content to clarify secrets management
+- Streamline custom persona injection in streamlit
+
+### Removed
+- N/A
+
 ## 0.1.2 (2022-11-14)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ If you plan to run the Streamlit app locally, you can add the key to `.streamlit
 COHERE_API_KEY = "YOUR_API_KEY_HERE"
 ```
 
-Alternatively, set the key as an environment variable by running the following command from the command line.
+When running locally, Streamlit will read the `secrets.toml` file and silently inject these values into the environment variables. Alternatively, you may directly set the API key as an environment variable by running the following command from the command line:
 ```
 export COHERE_API_KEY = "YOUR_API_KEY_HERE"
 ```

--- a/README.md
+++ b/README.md
@@ -76,25 +76,33 @@ Want to see it in action first? You can use `conversant` on a [Streamlit](https:
   <img src="https://github.com/cohere-ai/sandbox-conversant-lib/raw/main/static/fortune-teller-chat.png" alt="Screenshot showing an exchange between a Fortune Teller chatbot and a user." height="550"/>
 </p>
 
-### Running Your Own Demo Locally
+### Running Your Own Streamlit Demo
 
 Cohere uses Streamlit to create its demo applications. If you’re new to Streamlit, you can install it [here](https://docs.streamlit.io/library/get-started/installation) and read more about running Streamlit commands [here](https://docs.streamlit.io/library/get-started/main-concepts).
 
 If you'd like to spin up your own instance of the Streamlit demo, you will first need a `COHERE_API_KEY`. 
 You can generate one by visiting [dashboard.cohere.ai](https://dashboard.cohere.ai/welcome/register?utm_source=github&utm_medium=content&utm_campaign=sandbox&utm_content=conversant). 
-Add the key to `.streamlit/secrets.toml`:
+
+#### Local Streamlit apps
+If you plan to run the Streamlit app locally, you can add the key to `.streamlit/secrets.toml`:
 ```
 COHERE_API_KEY = "YOUR_API_KEY_HERE"
 ```
 
-Alternatively, set the key as an environment variable.
+Alternatively, set the key as an environment variable by running the following command from the command line.
 ```
 export COHERE_API_KEY = "YOUR_API_KEY_HERE"
 ```
 
- Start the Streamlit app from `conversant/demo/streamlit_example.py`:
+Start the Streamlit app from the command line with the following command:
 ```
 streamlit run conversant/demo/streamlit_example.py
+```
+
+#### Hosted Streamlit apps
+If instead you would like to create a hosted Streamlit app, add your Cohere API key to Streamlit via [Secrets Management](https://docs.streamlit.io/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management). Add the following line as a Secret:
+```
+COHERE_API_KEY = "YOUR_API_KEY_HERE"
 ```
 
 ### Creating a Custom Persona

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "conversant"
-version = "0.1.2"
+version = "0.1.3"
 repository = "https://github.com/cohere-ai/sandbox-conversant-lib"
 description = "Conversational AI tooling"
 readme = "README.md"


### PR DESCRIPTION
### What this PR does

Closes #68, updates PyPI `CHANGELOG` and increments version number.

This adds details on how to do Secrets Management for hosted Streamlit apps and explains environment variable injection from `secrets.toml`.

### How it was tested

Documentation changes only.

### PR checklist

- [x] No API keys or other secrets committed to source?
- [x] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
