### PR TITLE
[CNV-89] feat: find persona in both default and custom dir

### DIFF
--- a/tests/test_prompt_chatbot.py
+++ b/tests/test_prompt_chatbot.py
@@ -68,11 +68,6 @@ def test_prompt_chatbot_init_from_persona(mock_co: object) -> None:
     check_prompt_chatbot_config(prompt_chatbot)
     prompt_chatbot.reply(query="What's up?")
 
-    with pytest.raises(FileNotFoundError):
-        _ = PromptChatbot.from_persona(
-            "watch-sales-agent", client=mock_co, persona_dir=""
-        )
-
 
 @pytest.mark.parametrize(
     "max_context_examples, history_length",

--- a/tests/test_prompt_chatbot.py
+++ b/tests/test_prompt_chatbot.py
@@ -7,6 +7,10 @@
 # level of this repository.
 
 import itertools
+import json
+import os
+import tempfile
+from typing import Any, Dict
 
 import pytest
 
@@ -55,7 +59,7 @@ def test_prompt_chatbot_init(mock_prompt_chatbot: PromptChatbot) -> None:
 
 
 def test_prompt_chatbot_init_from_persona(mock_co: object) -> None:
-    """Tests end to end that a prompt_chatbot is initalized correctly from persona.
+    """Tests end to end that a PromtpChatbot is initalized correctly from persona.
 
     Args:
         mock_co (object): mock Cohere client.
@@ -67,6 +71,38 @@ def test_prompt_chatbot_init_from_persona(mock_co: object) -> None:
     assert prompt_chatbot.latest_prompt == prompt_chatbot.prompt.to_string()
     check_prompt_chatbot_config(prompt_chatbot)
     prompt_chatbot.reply(query="What's up?")
+
+
+def test_prompt_chatbot_init_from_custom_dir(
+    mock_co: object, mock_chat_prompt_config: Dict[str, Any]
+) -> None:
+    """Tests end ot end that a PromptChatbot is initialized from a custom dir correctly.
+
+    Args:
+        mock_co (object): mock Cohere client.
+        mock_chat_prompt_config (Dict[str, Any]): A mock chat prompt config.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        persona_config = {
+            "chatbot_config": {},
+            "client_config": {},
+            "chat_prompt_config": mock_chat_prompt_config,
+        }
+        temp_persona = "temp"
+        os.mkdir(f"{temp_dir}/{temp_persona}")
+        with open(f"{temp_dir}/{temp_persona}/config.json", "w+") as temp_file:
+            json.dump(persona_config, temp_file)
+
+        for persona in [temp_persona, "watch-sales-agent"]:
+            prompt_chatbot = PromptChatbot.from_persona(
+                persona, client=mock_co, custom_persona_dir=temp_dir
+            )
+            assert isinstance(prompt_chatbot, PromptChatbot)
+            assert prompt_chatbot.user_name == prompt_chatbot.prompt.user_name
+            assert prompt_chatbot.bot_name == prompt_chatbot.prompt.bot_name
+            assert prompt_chatbot.latest_prompt == prompt_chatbot.prompt.to_string()
+            check_prompt_chatbot_config(prompt_chatbot)
+            prompt_chatbot.reply(query="What's up?")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!---OPEN_ANNOTATION-->
- #78 👈
<!---CLOSE_ANNOTATION-->

### What this PR does
- In PromptChatbot.from_persona, find the given persona in both the default `PERSONA_MODEL_DIRECTORY` and the `custom_persona_dir`



### How it was tested
- All tests pass
- Adds a test for initializing a prompt chatbot from a temporary persona in a custom temp dir


### PR checklist

- [x] No API keys or other secrets committed to source?
- [x] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
