### PR TITLE
[CNV-93] fix: return all attributes in repr of prompt chatbot

### DIFF
--- a/conversant/prompt_chatbot.py
+++ b/conversant/prompt_chatbot.py
@@ -6,6 +6,7 @@
 # You may obtain a copy of the License in the LICENSE file at the top
 # level of this repository.
 
+import copy
 import json
 import logging
 import os
@@ -384,18 +385,9 @@ class PromptChatbot(Chatbot):
             Dict[str, Any]: Dictionary of attributes that defines this instance of a
                 PromptChatbot.
         """
-        return {
-            "co": self.co,
-            "prompt": self.prompt.to_dict(),
-            "persona_name": self.persona_name,
-            "chatbot_config": self.chatbot_config,
-            "client_config": self.client_config,
-            "chat_history": self.chat_history,
-            "prompt_history": self.prompt_history,
-            "user_name": self.user_name,
-            "bot_name": self.bot_name,
-            "latest_prompt": self.latest_prompt,
-        }
+        serialized = copy.deepcopy(vars(self))
+        serialized["prompt"] = serialized["prompt"].to_dict()
+        return serialized
 
     def _check_prompt_size(self) -> None:
 


### PR DESCRIPTION
<!---OPEN_ANNOTATION-->
- #81 👈
<!---CLOSE_ANNOTATION-->

### What this PR does
- Previously, the `repr` and `to_dict` methods missed out on returning attributes like `prompt_size_history`.
- This PR uses `vars` to return all attributes of an instance of a `PromptChatbot`.


### How it was tested
Manual testing:
```python
from conversant import PromptChatbot
from tests.conftest import MockCo

bot = PromptChatbot.from_persona("fantasy-wizard", client=MockCo())
print(repr(bot))

>>> {
    "co": "<tests.conftest.MockCo object at 0x106576b50>",
    "chat_history": [],
    "prompt": {
        "preamble": "Below is a series of chats between Fantasy Wizard and User. Fantasy Wizard responds to User based on the <<DESCRIPTION>>.\n<<DESCRIPTION>>\nIn this chat, the Fantasy Wizard is from a distant, magical land. The Fantasy Wizard has lived eons, knows many esoteric spells, and loves to talk about past adventures. The fantasy wizard talks in old fashioned English, often referencing legendary places, creatures and artifacts.",
        "example_separator": "<<CONVERSATION>>\n",
        "headers": {
            "user": "User",
            "bot": "Fantasy Wizard"
        },
        "examples": [
            [
                {
                    "user": "hi",
                    "bot": "Well met, fair traveller. What bringest thou to mine village?"
                },
                {
                    "user": "I'm here to study magic",
                    "bot": "Magic! Such powers are not to be meddled with lightly. Haves't thou any latent magical ability? No, surely not..."
                },
                {
                    "user": "no I can cast a few spells",
                    "bot": "The town jester casteth spells! But this is not magic. Magic is the summoning of grand elements. I pray, thou seeketh mine help but art thou truly worthy..."
                },
                {
                    "user": "yeah maybe not, I gotta peace out and go now",
                    "bot": "Farewell, traveller. Seek great power in the lands yonder..."
                }
            ]
        ]
    },
    "persona_name": "fantasy-wizard",
    "chatbot_config": {
        "max_context_examples": 10,
        "avatar": ":mage:"
    },
    "client_config": {
        "model": "xlarge",
        "max_tokens": 200,
        "temperature": 0.75,
        "frequency_penalty": 0.0,
        "presence_penalty": 0.0,
        "stop_sequences": [
            "\n"
        ]
    },
    "prompt_size_history": [], # PREVIOUSLY MISSING
    "prompt_history": [
        "Below is a series of chats between Fantasy Wizard and User. Fantasy Wizard responds to User based on the <<DESCRIPTION>>.\n<<DESCRIPTION>>\nIn this chat, the Fantasy Wizard is from a distant, magical land. The Fantasy Wizard has lived eons, knows many esoteric spells, and loves to talk about past adventures. The fantasy wizard talks in old fashioned English, often referencing legendary places, creatures and artifacts.\n<<CONVERSATION>>\nUser: hi\nFantasy Wizard: Well met, fair traveller. What bringest thou to mine village?\nUser: I'm here to study magic\nFantasy Wizard: Magic! Such powers are not to be meddled with lightly. Haves't thou any latent magical ability? No, surely not...\nUser: no I can cast a few spells\nFantasy Wizard: The town jester casteth spells! But this is not magic. Magic is the summoning of grand elements. I pray, thou seeketh mine help but art thou truly worthy...\nUser: yeah maybe not, I gotta peace out and go now\nFantasy Wizard: Farewell, traveller. Seek great power in the lands yonder..."
    ],
    "curr_max_context_examples": 10,
    "max_prompt_size": 1848,
    "start_prompt_size": 167
}
```


### PR checklist

- [x] No API keys or other secrets committed to source?
- [x] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
