### PR TITLE
[CNV-134] use emojificate fork pointing to new twemoji CDN

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -41,7 +41,7 @@ python-versions = ">=3.5"
 dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
 tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "autoflake"
@@ -129,7 +129,7 @@ optional = false
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode-backport = ["unicodedata2"]
+unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -201,17 +201,24 @@ dev = ["coverage", "coveralls", "pytest"]
 
 [[package]]
 name = "emojificate"
-version = "0.6.0"
+version = "0.post0.dev74"
 description = "Convert emoji in HTML to fallback images, alt text, title text, and aria labels."
 category = "main"
 optional = false
 python-versions = "*"
+develop = false
 
 [package.dependencies]
 click = "*"
 emoji = "*"
 grapheme = "*"
 requests = "*"
+
+[package.source]
+type = "git"
+url = "https://github.com/mahtoid/emojificate.git"
+reference = "HEAD"
+resolved_reference = "6b6fccb45b4450823d1862d2866ca93237fba861"
 
 [[package]]
 name = "entrypoints"
@@ -345,9 +352,9 @@ python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
-pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
 plugins = ["setuptools"]
-requirements-deprecated-finder = ["pip-api", "pipreqs"]
+requirements_deprecated_finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "Jinja2"
@@ -702,7 +709,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "rich"
@@ -967,7 +974,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "205d42dec2e04a920c8527e0c72ee7cf14c31e1bd293395f68b7ba2269d936f0"
+content-hash = "77b777f8aa944b0389b7d742c4b23131dfd9112794b2d7a1afa934bde3423aa3"
 
 [metadata.files]
 altair = [
@@ -1073,9 +1080,7 @@ distlib = [
 emoji = [
     {file = "emoji-2.2.0.tar.gz", hash = "sha256:a2986c21e4aba6b9870df40ef487a17be863cb7778dcf1c01e25917b7cd210bb"},
 ]
-emojificate = [
-    {file = "emojificate-0.6.0-py2.py3-none-any.whl", hash = "sha256:eca9fdd0678596717e661ff195b04f26b4c96ffb53b4bb076e4c802680212e93"},
-]
+emojificate = []
 entrypoints = [
     {file = "entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f"},
     {file = "entrypoints-0.4.tar.gz", hash = "sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4"},
@@ -1253,8 +1258,6 @@ pdoc = [
     {file = "pdoc-12.2.1.tar.gz", hash = "sha256:2f2f3b667bc52e2bc13b87cf7460db5e4f2484269c9c4bad22a2d5514eaae1ce"},
 ]
 Pillow = [
-    {file = "Pillow-9.3.0-1-cp37-cp37m-win32.whl", hash = "sha256:e6ea6b856a74d560d9326c0f5895ef8050126acfdc7ca08ad703eb0081e82b74"},
-    {file = "Pillow-9.3.0-1-cp37-cp37m-win_amd64.whl", hash = "sha256:32a44128c4bdca7f31de5be641187367fe2a450ad83b833ef78910397db491aa"},
     {file = "Pillow-9.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:0b7257127d646ff8676ec8a15520013a698d1fdc48bc2a79ba4e53df792526f2"},
     {file = "Pillow-9.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b90f7616ea170e92820775ed47e136208e04c967271c9ef615b6fbd08d9af0e3"},
     {file = "Pillow-9.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68943d632f1f9e3dce98908e873b3a090f6cba1cbb1b892a9e8d97c938871fbe"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ cohere = "^2.8.0"
 toml = "^0.10.2"
 pydantic = "^1.10.2"
 emoji = "^2.1.0"
-emojificate = "^0.6.0"
+emojificate = {git = "https://github.com/mahtoid/emojificate.git"}
 streamlit-ace = "^0.1.1"
 streamlit-talk = "^0.0.3"
 


### PR DESCRIPTION
<!---OPEN_ANNOTATION-->
- #86 👈
- #87 
<!---CLOSE_ANNOTATION-->

Closes CNV-134

### What this PR does
- Updates the emojificate dependency in poetry to use [this fork](https://github.com/mahtoid/emojificate), which points to the [new twemoji CDN](https://github.com/twitter/twemoji/commit/abb5a1add2b706520d0d9d6f023297761e64e1c7) and has an [active pull request](https://github.com/glasnt/emojificate/pull/16) into the official emojificate repo (as at this time of writing)


### How it was tested
Before:
<img width="428" alt="Screenshot 2023-01-10 at 2 40 59 PM" src="https://user-images.githubusercontent.com/32623504/211481153-a0af5b91-7451-44af-af38-7dbb700c4cb9.png">

After:
<img width="463" alt="Screenshot 2023-01-10 at 2 50 37 PM" src="https://user-images.githubusercontent.com/32623504/211481182-3cd3cf42-fa0b-41df-8ce6-c41e5ca3216e.png">




### PR checklist

- [x] No API keys or other secrets committed to source?
- [x] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
