### PR TITLE
[CNV-134] point to twemoji CDN within conversant, not with new dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - N/A
 
 ### Changed
-- Bug fix of twemoji MaxCDN outage by updating emojificate dependency to a fork with new CDN
+- Bug fix of twemoji MaxCDN outage
 
 ### Removed
 - N/A

--- a/conversant/demo/utils.py
+++ b/conversant/demo/utils.py
@@ -13,11 +13,14 @@ import re
 from typing import List
 
 import emoji
+import emojificate
 import streamlit as st
-from emojificate.filter import emojificate
+from emojificate.filter import emojificate as emojificate_fn
 
 from conversant.prompt_chatbot import PERSONA_MODEL_DIRECTORY, PromptChatbot
 from conversant.prompts.chat_prompt import ChatPrompt
+
+emojificate.filter.TWITTER_CDN = "https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2"
 
 
 class ParrotChatbot(PromptChatbot):
@@ -74,7 +77,7 @@ def get_twemoji_url_from_shortcode(shortcode: str) -> str:
     # Emojize returns the unicode representation of that emoji from its shortcode.
     unicode = emoji.emojize(shortcode, language="alias")
     # Emojificate returns html <img /> tag.
-    img_html_tag = emojificate(unicode)
+    img_html_tag = emojificate_fn(unicode)
     # Find the URL from the html tag.
     url = re.findall('src="(.*?)"', img_html_tag, re.DOTALL)[0]
     return url

--- a/poetry.lock
+++ b/poetry.lock
@@ -201,24 +201,17 @@ dev = ["coverage", "coveralls", "pytest"]
 
 [[package]]
 name = "emojificate"
-version = "0.post0.dev74"
+version = "0.6.0"
 description = "Convert emoji in HTML to fallback images, alt text, title text, and aria labels."
 category = "main"
 optional = false
 python-versions = "*"
-develop = false
 
 [package.dependencies]
 click = "*"
 emoji = "*"
 grapheme = "*"
 requests = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/mahtoid/emojificate.git"
-reference = "HEAD"
-resolved_reference = "6b6fccb45b4450823d1862d2866ca93237fba861"
 
 [[package]]
 name = "entrypoints"
@@ -974,7 +967,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "77b777f8aa944b0389b7d742c4b23131dfd9112794b2d7a1afa934bde3423aa3"
+content-hash = "205d42dec2e04a920c8527e0c72ee7cf14c31e1bd293395f68b7ba2269d936f0"
 
 [metadata.files]
 altair = [
@@ -1080,7 +1073,9 @@ distlib = [
 emoji = [
     {file = "emoji-2.2.0.tar.gz", hash = "sha256:a2986c21e4aba6b9870df40ef487a17be863cb7778dcf1c01e25917b7cd210bb"},
 ]
-emojificate = []
+emojificate = [
+    {file = "emojificate-0.6.0-py2.py3-none-any.whl", hash = "sha256:eca9fdd0678596717e661ff195b04f26b4c96ffb53b4bb076e4c802680212e93"},
+]
 entrypoints = [
     {file = "entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f"},
     {file = "entrypoints-0.4.tar.gz", hash = "sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ cohere = "^2.8.0"
 toml = "^0.10.2"
 pydantic = "^1.10.2"
 emoji = "^2.1.0"
-emojificate = {git = "https://github.com/mahtoid/emojificate.git"}
+emojificate = "^0.6.0"
 streamlit-ace = "^0.1.1"
 streamlit-talk = "^0.0.3"
 


### PR DESCRIPTION
<!---OPEN_ANNOTATION-->
- #89 👈
<!---CLOSE_ANNOTATION-->

N.B. First commit message should read revert #86 

### What this PR does
- Reverts #86 as setting a dependency to a github repo is not a viable solution. This would block publishing to PyPI as PyPI does not allow github repos as direct dependencies of a package
- Instead, we point emojificate to the correct CDN from within conversant
- Updates changelog 



### How it was tested
- Streamlit demo is able to show twemojis again
![Screenshot 2023-01-11 at 10 41 31 PM](https://user-images.githubusercontent.com/32623504/211834884-069192bb-28b2-4ff2-8f6f-a023a6d1315b.png)


### PR checklist

- [x] No API keys or other secrets committed to source?
- [x] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```

