### PR TITLE
[0.1.6] fix: save stop sequences when swapping personas

### DIFF
--- a/conversant/demo/streamlit_example.py
+++ b/conversant/demo/streamlit_example.py
@@ -72,6 +72,10 @@ def update_session_with_prompt() -> None:
         st.session_state.snapshot_client_config = copy.deepcopy(
             st.session_state.bot.client_config
         )
+        st.session_state.current_stop_sequences = [
+            utils.escape_string(stop_seq)
+            for stop_seq in st.session_state.bot.client_config["stop_sequences"]
+        ]
 
 
 def update_prompt_from_json() -> None:


### PR DESCRIPTION

- #90<!---OPEN_ANNOTATION-->
- #91 👈
- #92
<!---CLOSE_ANNOTATION-->
CNV-168
### What this PR does
- In the streamlit demo, saves the stop sequences from `st.session_state.bot` in `st.session_state.current_stop_sequences`, so that when changing personas, the stop sequences are referenced from the new persona, and not the old one


### How it was tested
Before:
Persona with `\nUser` stop sequence     |  Persona with `\n` stop sequence
:-------------------------:|:-------------------------:
![Screenshot 2023-01-13 at 6 08 39 PM](https://user-images.githubusercontent.com/32623504/212296996-80c37b5f-7525-4c7f-a3f7-fa4b5cf16921.png) | ![Screenshot 2023-01-13 at 6 08 59 PM](https://user-images.githubusercontent.com/32623504/212297145-08996694-9e50-482d-8f53-b02b771df70b.png)

After:
Persona with `\nUser` stop sequence     |  Persona with `\n` stop sequence
:-------------------------:|:-------------------------:
![Screenshot 2023-01-13 at 6 10 41 PM](https://user-images.githubusercontent.com/32623504/212297318-1371081c-83b2-4cdb-b325-5539d6eaf5e9.png) |  ![Screenshot 2023-01-13 at 6 10 52 PM](https://user-images.githubusercontent.com/32623504/212297342-e22666b2-7c46-4108-aefb-05303cde1a9c.png)

### PR checklist

- [x] No API keys or other secrets committed to source?
- [x] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
