### PR TITLE
[CNV-177] feat: allow any numeric input for max_tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.1.7 (2023-01-16)
+
+### Added
+- N/A
+
+### Changed
+- Changed `client_config` form in Streamlit demo to allow any number of `max_tokens`
+
+### Removed
+- N/A
+
 ## 0.1.6 (2023-01-13)
 
 ### Added

--- a/conversant/demo/ui.py
+++ b/conversant/demo/ui.py
@@ -113,10 +113,8 @@ def draw_client_config_form() -> None:
             "WARNING: This demo does not validate that the model ID used for override "
             "is valid.",
         )
-    max_tokens = st.slider(
+    max_tokens = st.number_input(
         label="max_tokens",
-        min_value=50,
-        max_value=250,
         value=config["max_tokens"],
         help="The number of tokens to predict per response.",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "conversant"
-version = "0.1.6"
+version = "0.1.7"
 repository = "https://github.com/cohere-ai/sandbox-conversant-lib"
 description = "Conversational AI tooling"
 readme = "README.md"


### PR DESCRIPTION
<!---OPEN_ANNOTATION-->
- #93 👈
<!---CLOSE_ANNOTATION-->
CNV-177
### What this PR does
- Changes input widget for `max_tokens` from `st.slider` to `st.numeric_input` to allow any number of `max_tokens` without a min or max
- Updates `conversant` to 0.1.7


### How it was tested
- Locally on streamlit demo
![Screenshot 2023-01-16 at 4 35 23 PM](https://user-images.githubusercontent.com/32623504/212633525-70e366c2-37a8-4829-a096-b890ad51c4d1.png)


### PR checklist

- [x] No API keys or other secrets committed to source?
- [x] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
