### PR TITLE
[CNV-192] fix: cast `max_tokens` to int when using `st.number_input`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.2.1 (2023-01-20)
+
+### Added
+- N/A
+
+### Changed
+- Fixed a bug in Streamlit demo by casting `max_tokens` to `int`
+
+### Removed
+- N/A
+
 ## 0.1.7 (2023-01-16)
 
 ### Added

--- a/conversant/demo/ui.py
+++ b/conversant/demo/ui.py
@@ -179,7 +179,7 @@ def draw_client_config_form() -> None:
     st.session_state.bot.configure_client(
         {
             "model": model_id_override,
-            "max_tokens": max_tokens,
+            "max_tokens": int(max_tokens),
             "temperature": temperature,
             "frequency_penalty": frequency_penalty,
             "presence_penalty": presence_penalty,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "conversant"
-version = "0.1.7"
+version = "0.2.1"
 repository = "https://github.com/cohere-ai/sandbox-conversant-lib"
 description = "Conversational AI tooling"
 readme = "README.md"


### PR DESCRIPTION
<!---OPEN_ANNOTATION-->
- #95 👈
<!---CLOSE_ANNOTATION-->
CNV-192
### What this PR does
- Casts the return value of `st.number_input` to be an `int` so that `max_tokens` is passed to `co.generate` as an `int`


### How it was tested
- Tested manually on local streamlit that turns conversations after the first successfully get responses
![Screenshot 2023-01-20 at 5 35 18 PM](https://user-images.githubusercontent.com/32623504/213663066-bdb8538e-3086-41eb-b955-9869c6e9e2b0.png)


### PR checklist

- [x] No API keys or other secrets committed to source?
- [ ] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
