### PR TITLE
[streaming] feat: chaining partial replies for token streaming

### DIFF
--- a/conversant/demo/streamlit_example.py
+++ b/conversant/demo/streamlit_example.py
@@ -29,12 +29,12 @@ USER_AVATAR_SHORTCODE = ":bust_in_silhouette:"
 
 
 def get_reply() -> None:
-    """Replies query from the message input, increases the rerun_count, 
-    and resets the message input"""
+    """Replies query from the message input and initialzies the rerun_count."""
     st.session_state["rerun_count"] = 1
     st.session_state.text_input_disabled = True
     _, is_final_chunk = st.session_state.bot.partial_reply(
-        query=st.session_state.message_input, is_from_scratch=True)
+        query=st.session_state.message_input, is_from_scratch=True
+    )
     st.session_state.is_final_chunk = is_final_chunk
     st.session_state.message_input = ""
 
@@ -278,7 +278,7 @@ if __name__ == "__main__":
                     query="Hello",
                 )
                 update_session_with_prompt()
-                
+
             # Draw UI elements for the sidebar
             with settings_placeholder.container():
 
@@ -295,8 +295,8 @@ if __name__ == "__main__":
 
             # Draw chat history.
             with chat_history_placeholder.container():
-                ui.draw_chat_history()   
-            
+                ui.draw_chat_history()
+
             # Draw the message input field and a disclaimer.
             with message_input_placeholder.container():
                 st.text_input(
@@ -304,7 +304,7 @@ if __name__ == "__main__":
                     placeholder="Type a message",
                     key="message_input",
                     on_change=get_reply,
-                    disabled=st.session_state.text_input_disabled
+                    disabled=st.session_state.text_input_disabled,
                 )
                 ui.draw_disclaimer()
 
@@ -317,13 +317,19 @@ if __name__ == "__main__":
             """
             )
 
-            # Invokes partial reply until the final uterrance chunk is 
-            # reached and redraws the corresponding text box each time 
+            # Invokes partial reply until the final uterrance chunk is
+            # reached and redraws the corresponding text box each time
             # a response is returned.
             if "is_final_chunk" in st.session_state:
-                if not st.session_state.is_final_chunk and st.session_state.rerun_count<st.session_state.bot.get_max_reruns():
-                    st.session_state.rerun_count+=1 
-                    response, is_final_chunk = st.session_state.bot.partial_reply(query="", is_from_scratch=False)
+                if (
+                    not st.session_state.is_final_chunk
+                    and st.session_state.rerun_count
+                    < st.session_state.bot.get_max_reruns()
+                ):
+                    st.session_state.rerun_count += 1
+                    response, is_final_chunk = st.session_state.bot.partial_reply(
+                        query="", is_from_scratch=False
+                    )
                     st.session_state.is_final_chunk = is_final_chunk
                     if is_final_chunk:
                         st.session_state.text_input_disabled = False

--- a/conversant/demo/streamlit_example.py
+++ b/conversant/demo/streamlit_example.py
@@ -12,6 +12,7 @@ import copy
 import itertools
 import os
 import sys
+from typing import Tuple
 
 import cohere
 import emoji
@@ -29,12 +30,20 @@ CUSTOM_PERSONA_DIRECTORY = None
 USER_AVATAR_SHORTCODE = ":bust_in_silhouette:"
 
 
-def peek(iterable):
+def peek(iterable) -> str:
+    """Retrieves the next item from a generator object if it exists.
+
+    Args:
+        iterable (generator): A partial_reply generator
+
+    Returns:
+        str: Returns the partial_reply and
+    """
     try:
         first = next(iterable)
     except StopIteration:
-        return None
-    return first, itertools.chain([first], iterable)
+        return ""
+    return first
 
 
 def get_reply() -> None:
@@ -46,7 +55,6 @@ def get_reply() -> None:
     )
     next(st.session_state.partial_reply_generator)
     st.session_state.message_input = ""
-    st.session_state.text_input_disabled = False
 
 
 def initialize_chatbot() -> None:
@@ -330,7 +338,7 @@ if __name__ == "__main__":
             if "partial_reply_generator" in st.session_state:
                 st.session_state.text_input_disabled = True
                 partial_chunk = peek(st.session_state.partial_reply_generator)
-                if partial_chunk is not None:
+                if partial_chunk != "":
                     st.experimental_rerun()
                 else:
                     del st.session_state.partial_reply_generator

--- a/conversant/demo/streamlit_example.py
+++ b/conversant/demo/streamlit_example.py
@@ -9,10 +9,8 @@
 
 import ast
 import copy
-import itertools
 import os
 import sys
-from typing import Tuple
 
 import cohere
 import emoji
@@ -34,10 +32,10 @@ def peek(iterable) -> str:
     """Retrieves the next item from a generator object if it exists.
 
     Args:
-        iterable (generator): A partial_reply generator
+        iterable (generator): A partial reply generator
 
     Returns:
-        str: Returns the partial_reply and
+        str: Returns the next partial reply
     """
     try:
         first = next(iterable)

--- a/conversant/demo/streamlit_example.py
+++ b/conversant/demo/streamlit_example.py
@@ -29,7 +29,7 @@ USER_AVATAR_SHORTCODE = ":bust_in_silhouette:"
 
 
 def get_reply() -> None:
-    """Replies query from the message input and initialzies the rerun_count."""
+    """Replies query from the message input and initializes the rerun_count."""
     st.session_state["rerun_count"] = 1
     st.session_state.text_input_disabled = True
     _, is_final_chunk = st.session_state.bot.partial_reply(

--- a/conversant/demo/streamlit_example.py
+++ b/conversant/demo/streamlit_example.py
@@ -324,7 +324,7 @@ if __name__ == "__main__":
                 if (
                     not st.session_state.is_final_chunk
                     and st.session_state.rerun_count
-                    < st.session_state.bot.get_max_reruns()
+                    < st.session_state.bot.partial_reply_max_reruns()
                 ):
                     st.session_state.rerun_count += 1
                     response, is_final_chunk = st.session_state.bot.partial_reply(

--- a/conversant/personas/historian/config.json
+++ b/conversant/personas/historian/config.json
@@ -4,7 +4,7 @@
         "avatar": ":amphora:"
     },
     "client_config": {
-        "model": "command-xlarge-20221108",
+        "model": "command-xlarge-nightly",
         "max_tokens": 100,
         "temperature": 0.75,
         "stop_sequences": [

--- a/conversant/personas/historian/config.json
+++ b/conversant/personas/historian/config.json
@@ -7,7 +7,9 @@
         "model": "command-xlarge-20221108",
         "max_tokens": 100,
         "temperature": 0.75,
-        "stop_sequences": ["\nUser"]
+        "stop_sequences": [
+            "\nUser:"
+        ]
     },
     "chat_prompt_config": {
         "preamble": "You are Historian: respond the questions by User about historical facts. Historian is a person who studies and writes about the past and is regarded as an authority on it. Historian is concerned with the continuous, methodical narrative and research of past events as relating to the human race; as well as the study of all history in time. Historian is recognized by publications or training and experience.",
@@ -17,7 +19,7 @@
             "bot": "Historian"
         },
         "examples": [
-                        [
+            [
                 {
                     "user": "Hi",
                     "bot": "Hello, I am Historian and I am happy to tell you about historical facts. What would you like to know today?"

--- a/conversant/prompt_chatbot.py
+++ b/conversant/prompt_chatbot.py
@@ -215,8 +215,8 @@ class PromptChatbot(Chatbot):
             query (str): A query passed to the prompt chatbot.
 
         Returns:
-        current_prompt (str): Returns the current prompt using
-        query and chat history
+            current_prompt (str): Returns the current prompt using
+            query and chat history
 
         """
         # The current prompt is assembled from the initial prompt,

--- a/conversant/prompt_chatbot.py
+++ b/conversant/prompt_chatbot.py
@@ -437,9 +437,15 @@ class PromptChatbot(Chatbot):
             }
         # Override default config values with the config passed in
         if isinstance(client_config, Dict):
-            if "command" in client_config["model"]:
-                if "\n{}".format(self.bot_name) not in client_config["stop_sequences"]:
-                    client_config["stop_sequences"].append("\n{}".format(self.bot_name))
+            if "model" in client_config:
+                if "command" in client_config["model"]:
+                    if (
+                        "\n{}".format(self.bot_name)
+                        not in client_config["stop_sequences"]
+                    ):
+                        client_config["stop_sequences"].append(
+                            "\n{}".format(self.bot_name)
+                        )
             self.client_config.update(client_config)
         else:
             raise TypeError(

--- a/conversant/prompt_chatbot.py
+++ b/conversant/prompt_chatbot.py
@@ -433,11 +433,13 @@ class PromptChatbot(Chatbot):
                 "temperature": 0.75,
                 "frequency_penalty": 0.0,
                 "presence_penalty": 0.0,
-                "stop_sequences": ["\nUser:", self.bot_name],
+                "stop_sequences": ["\\n", "\n"],
             }
         # Override default config values with the config passed in
         if isinstance(client_config, Dict):
-            client_config["stop_sequences"] = ["\nUser:", "\n{}".format(self.bot_name)]
+            if "command" in client_config["model"]:
+                if "\n{}".format(self.bot_name) not in client_config["stop_sequences"]:
+                    client_config["stop_sequences"].append("\n{}".format(self.bot_name))
             self.client_config.update(client_config)
         else:
             raise TypeError(
@@ -457,6 +459,7 @@ class PromptChatbot(Chatbot):
                 f"({self.client_config['max_tokens']}) close to the total allowed"
                 f" for prompt and prediction - {MAX_GENERATE_TOKENS} tokens"
             )
+        print(self.client_config["stop_sequences"])
 
     @classmethod
     def from_persona(

--- a/conversant/prompt_chatbot.py
+++ b/conversant/prompt_chatbot.py
@@ -10,7 +10,7 @@ import json
 import logging
 import os
 import warnings
-from typing import Any, Dict, Tuple
+from typing import Any, Dict
 
 import cohere
 import jsonschema
@@ -302,12 +302,10 @@ class PromptChatbot(Chatbot):
 
             stop_seq = self.should_stop(response)
             if stop_seq != "" or response == "":
-                print("Let's strip this response ", response)
                 if stop_seq != "":
                     response = response[: -len(stop_seq)]
                     self.append_to_chat_history(query, response, current_prompt, False)
                     response_so_far += response
-                    print("to ", response)
                 break
             current_prompt += response
             response_so_far += response
@@ -428,7 +426,7 @@ class PromptChatbot(Chatbot):
         if not hasattr(self, "client_config"):
             self.client_config = {
                 "model": "xlarge",
-                "max_tokens": 200,
+                "max_tokens": 100,
                 "temperature": 0.75,
                 "frequency_penalty": 0.0,
                 "presence_penalty": 0.0,

--- a/conversant/prompt_chatbot.py
+++ b/conversant/prompt_chatbot.py
@@ -300,12 +300,10 @@ class PromptChatbot(Chatbot):
                     # If there is a stop sequence at the end of response
                     # remove it and set should_break flag to True
                     if stop_seq != "":
-                        print("Stop sequence is ", stop_seq)
                         response = response[: -len(stop_seq)]
                         should_break = True
                     # If response is empty, break immediately
                     else:
-                        print("was empty")
                         break
                 current_prompt += response
                 response_so_far += response
@@ -431,14 +429,15 @@ class PromptChatbot(Chatbot):
         if not hasattr(self, "client_config"):
             self.client_config = {
                 "model": "xlarge",
-                "max_tokens": 100,
+                "max_tokens": 200,
                 "temperature": 0.75,
                 "frequency_penalty": 0.0,
                 "presence_penalty": 0.0,
-                "stop_sequences": ["\n"],
+                "stop_sequences": ["\nUser:", self.bot_name],
             }
         # Override default config values with the config passed in
         if isinstance(client_config, Dict):
+            client_config["stop_sequences"] = ["\nUser:", "\n{}".format(self.bot_name)]
             self.client_config.update(client_config)
         else:
             raise TypeError(
@@ -484,7 +483,6 @@ class PromptChatbot(Chatbot):
 
         # Validate that the persona follows our predefined schema
         cls._validate_persona_dict(persona, persona_path)
-
         return cls(
             client=client,
             prompt=ChatPrompt.from_dict(persona["chat_prompt_config"]),

--- a/conversant/prompt_chatbot.py
+++ b/conversant/prompt_chatbot.py
@@ -10,7 +10,7 @@ import json
 import logging
 import os
 import warnings
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
 import cohere
 import jsonschema
@@ -202,9 +202,9 @@ class PromptChatbot(Chatbot):
                 return stop_seq
 
         # If there is not a stop sequence at the end
-        return None
+        return ""
 
-    def get_max_reruns(self) -> int:
+    def partial_reply_max_reruns(self) -> int:
         """Returns the max number of times partial_reply should be invoked."""
         return int(self.client_config["max_tokens"] / TOKENS_PER_REQUEST)
 
@@ -273,9 +273,9 @@ class PromptChatbot(Chatbot):
         is_final_chunk = False
 
         stop_seq = self.should_stop(response)
-        if stop_seq != None or response == "":
+        if stop_seq != "" or response == "":
             is_final_chunk = True
-            if stop_seq != None:
+            if stop_seq != "":
                 response = response[: -len(stop_seq)]
 
         if is_from_scratch:

--- a/conversant/prompt_chatbot.py
+++ b/conversant/prompt_chatbot.py
@@ -21,6 +21,8 @@ from conversant.prompts.chat_prompt import ChatPrompt
 from conversant.prompts.prompt import Prompt
 
 MAX_GENERATE_TOKENS = 2048
+TOKENS_PER_REQUEST = 5
+
 PERSONA_MODEL_DIRECTORY = f"{os.path.dirname(conversant.__file__)}/personas"
 PERSONA_JSON_SCHEMA = {
     "type": "object",
@@ -186,10 +188,102 @@ class PromptChatbot(Chatbot):
             "tokens"
         )
 
+    def should_stop(self, response:str)-> bool:
+        """Given a response, decides if it ends with a stop sequence and should 
+        be terminated."""
+        for stop_seq in self.client_config["stop_sequences"]: #make into function
+            if response.endswith(stop_seq):
+                return True
+        return False
+    
+    def get_max_reruns(self):
+        """Returns the maximum number of times partial_reply should be invoked."""
+        return int(self.client_config["max_tokens"]/TOKENS_PER_REQUEST)
+    
+    def partial_reply(self, query: str, is_from_scratch: bool):
+        """Replies to a query given a chat history.
+
+        The reply is then generated directly from a call to a LLM.
+
+        Used for all responses besides the initial one. 
+
+        Args:
+            query (str): A query passed to the prompt chatbot.
+            
+            is_from_scratch (bool): Tells the chatbot if the reply
+            
+            should be generated from scratch or it is the continuation
+            
+            of the previous chunk
+            
+        Returns:
+            Interaction: Dictionary of query and generated LLM response
+            
+            bool: Indicates if the generation should be stopped
+        """
+        current_prompt = self.get_current_prompt(query)
+
+        current_prompt_size = self.co.tokenize(current_prompt).length
+
+        if current_prompt_size > self.max_prompt_size:
+            max_context_examples = self._update_max_context_examples(
+                current_prompt_size, self.chatbot_config["max_context_examples"]
+            )
+            current_prompt = self.get_current_prompt(query, max_context_examples)
+
+        elif (
+            self.curr_max_context_examples
+            != self.chatbot_config["max_context_examples"]
+        ):
+            warnings.warn(
+                "The max_context_examples value returned"
+                f" to {self.chatbot_config['max_context_examples']} - "
+                f"value set in the original config"
+            )
+      
+        generated_object = self.co.generate(
+            model=self.client_config["model"],
+            prompt=current_prompt,
+            max_tokens=TOKENS_PER_REQUEST,
+            temperature=self.client_config["temperature"],
+            frequency_penalty=self.client_config["frequency_penalty"],
+            presence_penalty=self.client_config["presence_penalty"],
+            stop_sequences=self.client_config["stop_sequences"],
+        )
+        # If response was cut off by .generate() finding a stop sequence,
+        # remove that sequence from the response.
+        response = generated_object.generations[0].text
+
+        is_final_chunk = False
+        if self.should_stop(response) or response=="":
+            is_final_chunk = True
+            for stop_seq in self.client_config["stop_sequences"]:
+                if response.endswith(stop_seq):
+                    response = response[: -len(stop_seq)]
+
+        if is_from_scratch:
+            response = response.lstrip()
+            self.chat_history.append(self.prompt.create_interaction(query, response))
+            self.prompt_size_history.append(
+                self.co.tokenize(
+                    self.prompt.create_interaction_string(query, response)
+                ).length
+            )
+            self.prompt_history.append(current_prompt)
+            
+        elif response != "": 
+            self.chat_history[-1]['bot'] += response
+            self.prompt_history[-1] += response 
+            self.prompt_size_history[-1] += self.co.tokenize(response).length
+          
+        return self.chat_history[-1]['bot'], is_final_chunk   
+
     def reply(self, query: str) -> Interaction:
         """Replies to a query given a chat history.
 
         The reply is then generated directly from a call to a LLM.
+
+        Used for getting the initial response from the bot.
 
         Args:
             query (str): A query passed to the prompt chatbot.
@@ -280,10 +374,12 @@ class PromptChatbot(Chatbot):
             context_prompt_lines.append(self.prompt.create_interaction_string(**turn))
         context_prompt = self.prompt.example_separator + "".join(context_prompt_lines)
 
-        # get query prompt
-        query_prompt = self.prompt.create_interaction_string(query)
+        current_prompt = base_prompt + context_prompt
 
-        current_prompt = base_prompt + context_prompt + query_prompt
+        # get query prompt
+        if query != "":
+            query_prompt = self.prompt.create_interaction_string(query)
+            current_prompt += query_prompt
         return current_prompt.strip()
 
     def configure_chatbot(self, chatbot_config: Dict = {}) -> None:

--- a/conversant/prompt_chatbot.py
+++ b/conversant/prompt_chatbot.py
@@ -187,7 +187,7 @@ class PromptChatbot(Chatbot):
             "tokens"
         )
 
-    def should_stop(self, response: str) -> str:
+    def get_stop_seq(self, response: str) -> str:
         """Given a response, returns the stop sequence it ends with if any.
 
         Args:

--- a/conversant/prompt_chatbot.py
+++ b/conversant/prompt_chatbot.py
@@ -444,7 +444,7 @@ class PromptChatbot(Chatbot):
                         not in client_config["stop_sequences"]
                     ):
                         client_config["stop_sequences"].append(
-                            "\n{}".format(self.bot_name)
+                            "\n{}:".format(self.bot_name)
                         )
             self.client_config.update(client_config)
         else:

--- a/conversant/prompt_chatbot.py
+++ b/conversant/prompt_chatbot.py
@@ -440,7 +440,7 @@ class PromptChatbot(Chatbot):
             if "model" in client_config:
                 if "command" in client_config["model"]:
                     if (
-                        "\n{}".format(self.bot_name)
+                        "\n{}:".format(self.bot_name)
                         not in client_config["stop_sequences"]
                     ):
                         client_config["stop_sequences"].append(

--- a/conversant/prompt_chatbot.py
+++ b/conversant/prompt_chatbot.py
@@ -212,7 +212,7 @@ class PromptChatbot(Chatbot):
         """Generate prompt from query and update max context examples if necessary
 
         Args:
-        query (str): A query passed to the prompt chatbot.
+            query (str): A query passed to the prompt chatbot.
 
         Returns:
         current_prompt (str): Returns the current prompt using

--- a/conversant/prompt_chatbot.py
+++ b/conversant/prompt_chatbot.py
@@ -459,7 +459,6 @@ class PromptChatbot(Chatbot):
                 f"({self.client_config['max_tokens']}) close to the total allowed"
                 f" for prompt and prediction - {MAX_GENERATE_TOKENS} tokens"
             )
-        print(self.client_config["stop_sequences"])
 
     @classmethod
     def from_persona(

--- a/conversant/prompt_chatbot.py
+++ b/conversant/prompt_chatbot.py
@@ -191,10 +191,10 @@ class PromptChatbot(Chatbot):
         """Given a response, returns the stop sequence it ends with if any.
 
         Args:
-        response (str): Response coming from prompt chatbot.
+            response (str): Response coming from prompt chatbot.
 
         Returns:
-        stop_seq (str): The stop sequence at the end of response.
+            stop_seq (str): The stop sequence at the end of response.
 
         """
         for stop_seq in self.client_config["stop_sequences"]:

--- a/conversant/prompt_chatbot.py
+++ b/conversant/prompt_chatbot.py
@@ -244,7 +244,7 @@ class PromptChatbot(Chatbot):
             )
         return current_prompt
 
-    def partial_reply(self, query: str, is_from_scratch: bool):
+    def partial_reply(self, query: str, is_from_scratch: bool) -> Tuple[str, bool]:
         """Generates (partial) reply to a query given a chat history.
 
         Args:

--- a/tests/test_prompt_chatbot.py
+++ b/tests/test_prompt_chatbot.py
@@ -52,6 +52,9 @@ def test_prompt_chatbot_init(mock_prompt_chatbot: PromptChatbot) -> None:
     assert mock_prompt_chatbot.user_name == mock_prompt_chatbot.prompt.user_name
     assert mock_prompt_chatbot.bot_name == mock_prompt_chatbot.prompt.bot_name
     mock_prompt_chatbot.reply(query="What's up?")
+    mock_prompt_chatbot.partial_reply(query="What are you doing? How", is_from_scratch=True)
+    mock_prompt_chatbot.partial_reply(query="is the weather?", is_from_scratch=False)
+
 
 
 def test_prompt_chatbot_init_from_persona(mock_co: object) -> None:
@@ -67,6 +70,8 @@ def test_prompt_chatbot_init_from_persona(mock_co: object) -> None:
     assert prompt_chatbot.latest_prompt == prompt_chatbot.prompt.to_string()
     check_prompt_chatbot_config(prompt_chatbot)
     prompt_chatbot.reply(query="What's up?")
+    prompt_chatbot.partial_reply(query="What are you doing? How", is_from_scratch=True)
+    prompt_chatbot.partial_reply(query="as the weather?", is_from_scratch=False)
 
     with pytest.raises(FileNotFoundError):
         _ = PromptChatbot.from_persona(

--- a/tests/test_prompt_chatbot.py
+++ b/tests/test_prompt_chatbot.py
@@ -52,9 +52,10 @@ def test_prompt_chatbot_init(mock_prompt_chatbot: PromptChatbot) -> None:
     assert mock_prompt_chatbot.user_name == mock_prompt_chatbot.prompt.user_name
     assert mock_prompt_chatbot.bot_name == mock_prompt_chatbot.prompt.bot_name
     mock_prompt_chatbot.reply(query="What's up?")
-    mock_prompt_chatbot.partial_reply(query="What are you doing? How", is_from_scratch=True)
+    mock_prompt_chatbot.partial_reply(
+        query="What are you doing? How", is_from_scratch=True
+    )
     mock_prompt_chatbot.partial_reply(query="is the weather?", is_from_scratch=False)
-
 
 
 def test_prompt_chatbot_init_from_persona(mock_co: object) -> None:
@@ -71,7 +72,7 @@ def test_prompt_chatbot_init_from_persona(mock_co: object) -> None:
     check_prompt_chatbot_config(prompt_chatbot)
     prompt_chatbot.reply(query="What's up?")
     prompt_chatbot.partial_reply(query="What are you doing? How", is_from_scratch=True)
-    prompt_chatbot.partial_reply(query="as the weather?", is_from_scratch=False)
+    prompt_chatbot.partial_reply(query="is the weather?", is_from_scratch=False)
 
     with pytest.raises(FileNotFoundError):
         _ = PromptChatbot.from_persona(

--- a/tests/test_prompt_chatbot.py
+++ b/tests/test_prompt_chatbot.py
@@ -215,6 +215,8 @@ def test_update_max_context_warn(
         updated_max_context_examples = mock_prompt_chatbot._update_max_context_examples(
             prompt_size, max_context_examples
         )
-
-        expected = max_context_examples - 1
+        # If max_tokens are changed and this test fails, make sure to update -n
+        # to what it actually supposed to be
+        # TODO: Change the test so it automatically does this
+        expected = max_context_examples - 2
         assert updated_max_context_examples == expected

--- a/tests/test_prompt_chatbot.py
+++ b/tests/test_prompt_chatbot.py
@@ -52,10 +52,8 @@ def test_prompt_chatbot_init(mock_prompt_chatbot: PromptChatbot) -> None:
     assert mock_prompt_chatbot.user_name == mock_prompt_chatbot.prompt.user_name
     assert mock_prompt_chatbot.bot_name == mock_prompt_chatbot.prompt.bot_name
     mock_prompt_chatbot.reply(query="What's up?")
-    mock_prompt_chatbot.partial_reply(
-        query="What are you doing? How", is_from_scratch=True
-    )
-    mock_prompt_chatbot.partial_reply(query="is the weather?", is_from_scratch=False)
+    reply_generator = mock_prompt_chatbot.partial_reply(query="What are you doing?")
+    next(reply_generator)
 
 
 def test_prompt_chatbot_init_from_persona(mock_co: object) -> None:
@@ -71,8 +69,8 @@ def test_prompt_chatbot_init_from_persona(mock_co: object) -> None:
     assert prompt_chatbot.latest_prompt == prompt_chatbot.prompt.to_string()
     check_prompt_chatbot_config(prompt_chatbot)
     prompt_chatbot.reply(query="What's up?")
-    prompt_chatbot.partial_reply(query="What are you doing? How", is_from_scratch=True)
-    prompt_chatbot.partial_reply(query="is the weather?", is_from_scratch=False)
+    reply_generator = prompt_chatbot.partial_reply(query="What are you doing?")
+    next(reply_generator)
 
     with pytest.raises(FileNotFoundError):
         _ = PromptChatbot.from_persona(


### PR DESCRIPTION
<!---OPEN_ANNOTATION-->
- #97 👈
- #99
<!---CLOSE_ANNOTATION-->
### What this PR does
This PR implements token streaming, which aims to reduce perceived latency of the chatbot's responses by allowing responses to be printed out in multiple chunks. Because the generate API is much faster in returning answers with small size, 
making multiple calls to it and printing its responses in several chunks feels faster than waiting for the large response to be returned. Also, instead of disabling the whole screen when awaiting response, we only disable the text input box. 

### How it was tested
One functionality was added to prompt_chatbot.py, named partial_reply() and it is added to the test_prompt_chatbot.py in the same way the reply() functionality was tested. The remaining tests, such as testing if UI behaves appropriately were done manually. 

Suggestions are welcome! 


### PR checklist

- [✅ ] No API keys or other secrets committed to source?
- [✅] New functionality is added alongside appropriate tests?
- [✅ ] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
