### PR TITLE
chore: update streamlit-talk to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,25 @@
 # Changelog
+
+## 0.2.5 (2023-03-10)
+
+### Added
+- N/A
+### Changed
+- Updated streamlit-talk to 0.2.1
+
+### Removed
+- N/A
+## 0.2.4 (2023-03-10)
+
+### Added
+- N/A
+### Changed
+- Updated streamlit-talk to 0.2.0
+
+### Removed
+- N/A
+
+
 ## 0.2.3 (2023-02-23)
 
 ### Added

--- a/poetry.lock
+++ b/poetry.lock
@@ -819,14 +819,14 @@ streamlit = ">=0.63"
 
 [[package]]
 name = "streamlit-talk"
-version = "0.1.9"
+version = "0.2.1"
 description = "A streamlit component, to make a UI for chat messages in Streamlit"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 
 [package.dependencies]
-streamlit = ">=0.63"
+streamlit = ">=1.18.1"
 
 [[package]]
 name = "toml"
@@ -974,7 +974,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,!=3.9.7"
-content-hash = "25f0de0dd67775cfbde8bbd92de36a08596904b2e5b52d5d552d5dde90087045"
+content-hash = "8ba7457e2eaed85195a271d59b2833d70a2be42e39ffb1f52cab5e1436b5f050"
 
 [metadata.files]
 altair = [
@@ -1688,8 +1688,7 @@ streamlit-ace = [
     {file = "streamlit_ace-0.1.1.tar.gz", hash = "sha256:1852fa19707685fd4241be9256c1ab1a89da4a3b8c28ab286e3bff122d3a1686"},
 ]
 streamlit-talk = [
-    {file = "streamlit-talk-0.1.9.tar.gz", hash = "sha256:3c2a08fd3b7d2f72611365ed909cbd3783b8a2390cd37d698c90e0428825597a"},
-    {file = "streamlit_talk-0.1.9-py3-none-any.whl", hash = "sha256:c112c8a13c6b9f45452e332bf5fe5c7616595021fbfbaf0c21679bff3a2f0cb2"},
+    {file = "streamlit-talk-0.2.1.tar.gz", hash = "sha256:af94234446cc3f6955dfe91232195012e49ca3f68c50f410f77ca332ca948f3e"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "conversant"
-version = "0.2.3"
+version = "0.2.5"
 repository = "https://github.com/cohere-ai/sandbox-conversant-lib"
 description = "Conversational AI tooling"
 readme = "README.md"
@@ -14,7 +14,7 @@ pydantic = "^1.10.2"
 emoji = "1.7.0"
 emojificate = "^0.6.0"
 streamlit-ace = "^0.1.1"
-streamlit-talk = "0.1.9"
+streamlit-talk = "^0.2.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.2"


### PR DESCRIPTION
### What this PR does
- Updates streamlit-talk to 0.2.1 which caches the call to `st_message`
- Pushes conversant 0.2.5 to PyPI (0.2.4 is skipped, as it has the wrong streamlit-talk version)


### How it was tested
- Update to dependencies only


### PR checklist

- [x] No API keys or other secrets committed to source?
- [x] New functionality is added alongside appropriate tests?
- [x] All source files have the following header?

```
# Copyright (c) {YEAR} Cohere Inc. and its affiliates.
#
# Licensed under the MIT License (the "License");
# you may not use this file except in compliance with the License.
#
# You may obtain a copy of the License in the LICENSE file at the top
# level of this repository.
```
